### PR TITLE
New variable statistics final energy by carrier oil

### DIFF
--- a/pypsa_validation_processing/configs/mapping.default.yaml
+++ b/pypsa_validation_processing/configs/mapping.default.yaml
@@ -6,6 +6,7 @@
 # Primary Energy|Coal: primary_energy_coal
 
 Final Energy [by Carrier]|Electricity: Final_Energy_by_Carrier__Electricity
+Final Energy [by Carrier]|Oil: Final_Energy_by_Carrier__Oil
 Final Energy [by Sector]|Transportation: Final_Energy_by_Sector__Transportation
 Final Energy [by Sector]|Industry: Final_Energy_by_Sector__Industry
 Final Energy [by Sector]|Agriculture: Final_Energy_by_Sector__Agriculture

--- a/pypsa_validation_processing/statistics_functions.py
+++ b/pypsa_validation_processing/statistics_functions.py
@@ -287,7 +287,10 @@ def Final_Energy_by_Carrier__Oil(
     all_oil = create_location_index_from_cupperplate(all_oil, home_location)
     all_oil = all_oil.groupby(kwargs["groupby"]).sum()
 
-    non_fossil_fraction = non_fossil_parts / all_oil
+    non_fossil_fraction = non_fossil_parts.div(all_oil)
+    zero_oil = all_oil.eq(0).reindex(non_fossil_fraction.index, fill_value=False)
+    non_fossil_fraction = non_fossil_fraction.mask(zero_oil, 1.0)
+
     non_fossil_fraction = non_fossil_fraction.clip(upper=1)  # TODO: Issue #53
     non_fossil_fraction = non_fossil_fraction.rename(index=UNITS_MAPPING)
     non_fossil_fraction = non_fossil_fraction.groupby(
@@ -295,6 +298,13 @@ def Final_Energy_by_Carrier__Oil(
     ).mean()  # avoid double-indexing
     total = total.rename(index=UNITS_MAPPING)
     total = total.groupby(kwargs["groupby"]).sum()
+
+    # cover edge-case with no oil demand
+    if all_oil.empty:
+        non_fossil_fraction = total * 0.0 + 1.0
+    else:
+        non_fossil_fraction = non_fossil_fraction.reindex_like(total).fillna(0.0)
+
     fossil_oil = total.mul(1 - non_fossil_fraction, axis=0)
     return fossil_oil
 

--- a/pypsa_validation_processing/statistics_functions.py
+++ b/pypsa_validation_processing/statistics_functions.py
@@ -30,8 +30,8 @@ from pypsa_validation_processing.utils import (
     statistics_kwargs_for_filtering as kwargs_filtering,
 )
 from pypsa_validation_processing.utils import (
-    statistics_grouping_index,
     get_energy_totals_domestic_share,
+    create_location_index_from_cupperplate,
 )
 
 
@@ -88,6 +88,67 @@ def Final_Energy_by_Carrier__Electricity(
         .groupby(["location", "unit"])
         .sum()
     )
+
+
+def Final_Energy_by_Carrier__Oil(
+    n: pypsa.Network,
+    aggregate_per_year: bool = True,
+) -> pd.Series | pd.DataFrame:
+    """Docstring oil from cupperplate to AT"""
+
+    # TODO: calculate the fraction of renewable oil regionwise
+
+    # Final Energy|Agricultur|Liquids - agriculture machinery oil
+    agri = n.statistics.withdrawal(
+        carrier="agriculture machinery oil",
+        components="Load",
+        aggregate_time=aggregate_per_year,
+        **kwargs,
+    )
+
+    # Final Energy|Residential and Commercial|Liquids - urban decentral oil boiler, rural oil boiler
+    raw_rescom = n.statistics.withdrawal(
+        bus_carrier="oil",
+        carrier=["rural oil boiler", "urban decentral oil boiler"],
+        groupby=kwargs_filtering["groupby"] + ["bus1"],
+        aggregate_time=aggregate_per_year,
+    )
+    if raw_rescom.empty:
+        rescom = raw_rescom
+    else:
+        raw_rescom = raw_rescom.drop("Store", errors="ignore")
+        usage_location = [
+            bus.split(" ")[0] for bus in list(raw_rescom.index.get_level_values("bus1"))
+        ]
+        rescom = (
+            create_location_index_from_cupperplate(raw_rescom, usage_location)
+            .groupby(kwargs["groupby"])
+            .sum()
+        )
+
+    # Final Energy|Transportation|Liquids
+    transpo = n.statistics.withdrawal(
+        carrier="land transport oil", components="Load", **kwargs
+    )
+
+    # Final Energy|Industry|Liquids - naphtha for industry
+    industry = n.statistics.withdrawal(
+        bus_carrier="naphtha for industry",
+        carrier="naphtha for industry",
+        components="Load",
+        aggregate_time=aggregate_per_year,
+        **kwargs,
+    )
+    series_list = [
+        agri,
+        rescom,
+        transpo,
+        industry,
+    ]
+    series_list = [series for series in series_list if not series.empty]
+
+    total = pd.concat(series_list)
+    return total
 
 
 def Final_Energy_by_Sector__Transportation(

--- a/pypsa_validation_processing/statistics_functions.py
+++ b/pypsa_validation_processing/statistics_functions.py
@@ -188,10 +188,10 @@ def Final_Energy_by_Carrier__Oil(
     are not represented in this statistic.
 
     ``UNITS_MAPPING`` is applied inside this function to enable multiplication
-    with demand-side units of renewable-oil-fraction``.
+    with demand-side units of the renewable-oil fraction.
     """
 
-    # Final Energy|Agricultur|Liquids - agriculture machinery oil
+    # Final Energy|Agriculture|Liquids - agriculture machinery oil
     agri = n.statistics.withdrawal(
         carrier="agriculture machinery oil",
         components="Load",

--- a/pypsa_validation_processing/statistics_functions.py
+++ b/pypsa_validation_processing/statistics_functions.py
@@ -25,9 +25,10 @@ from pathlib import Path
 import pandas as pd
 import numpy as np
 import pypsa
-from pypsa_validation_processing.utils import statistics_kwargs as kwargs
 from pypsa_validation_processing.utils import (
     statistics_kwargs_for_filtering as kwargs_filtering,
+    statistics_kwargs as kwargs,
+    UNITS_MAPPING,
 )
 from pypsa_validation_processing.utils import (
     get_energy_totals_domestic_share,
@@ -128,27 +129,82 @@ def Final_Energy_by_Carrier__Oil(
 
     # Final Energy|Transportation|Liquids
     transpo = n.statistics.withdrawal(
-        carrier="land transport oil", components="Load", **kwargs
-    )
-
-    # Final Energy|Industry|Liquids - naphtha for industry
-    industry = n.statistics.withdrawal(
-        bus_carrier="naphtha for industry",
-        carrier="naphtha for industry",
+        carrier="land transport oil",
         components="Load",
         aggregate_time=aggregate_per_year,
         **kwargs,
     )
+
     series_list = [
         agri,
         rescom,
         transpo,
-        industry,
     ]
     series_list = [series for series in series_list if not series.empty]
 
-    total = pd.concat(series_list)
-    return total
+    total = pd.concat(series_list).groupby(kwargs["groupby"]).sum()
+
+    # non-fossil parts from renewable-gas production per location
+    # renewable oil production
+    non_fossil_parts = n.statistics.supply(
+        bus_carrier="oil",
+        carrier=[
+            "unsustainable bioliquids",
+            "biomass to liquid",
+            "biomass to liquid CC",
+            "electrobiofuels",
+            "Fischer-Tropsch",
+        ],
+        at_port="bus1",
+        components="Link",
+        groupby=kwargs_filtering["groupby"] + ["bus0"],
+    )
+    home_location = [
+        bus.split(" ")[0]
+        for bus in list(non_fossil_parts.index.get_level_values("bus0"))
+    ]
+
+    non_fossil_parts = create_location_index_from_cupperplate(
+        non_fossil_parts, home_location
+    )
+    non_fossil_parts = non_fossil_parts.groupby(kwargs["groupby"]).sum()
+
+    # all oil use
+    all_oil = n.statistics.withdrawal(
+        bus_carrier="oil",
+        carrier=[
+            "land transport oil",
+            "naphtha for industry",
+            "shipping oil",
+            "kerosene for aviation",
+            "agriculture machinery oil",
+            "urban central oil CHP",
+            "oil",
+            "rural oil boiler",
+            "urban decentral oil boiler",
+        ],
+        components="Link",
+        at_port="bus0",
+        groupby=["bus1", "carrier", "location", "unit"],
+    )
+
+    home_location = [
+        bus.split(" ")[0] for bus in list(all_oil.index.get_level_values("bus1"))
+    ]
+
+    all_oil = create_location_index_from_cupperplate(all_oil, home_location)
+    all_oil = all_oil.groupby(kwargs["groupby"]).sum()
+
+    non_fossil_fraction = non_fossil_parts / all_oil
+    non_fossil_fraction = non_fossil_fraction.clip(upper=1)  # TODO: Issue #53
+    non_fossil_fraction = non_fossil_fraction.rename(index=UNITS_MAPPING)
+    non_fossil_fraction = non_fossil_fraction.groupby(
+        kwargs["groupby"]
+    ).mean()  # avoid double-indexing
+    total = total.rename(index=UNITS_MAPPING)
+    total = total.groupby(kwargs["groupby"]).sum()
+    fossil_oil = total.mul(1 - non_fossil_fraction, axis=0)
+    return fossil_oil
 
 
 def Final_Energy_by_Sector__Transportation(

--- a/pypsa_validation_processing/statistics_functions.py
+++ b/pypsa_validation_processing/statistics_functions.py
@@ -33,7 +33,7 @@ from pypsa_validation_processing.utils import (
 )
 from pypsa_validation_processing.utils import (
     get_energy_totals_domestic_share,
-    create_location_index_from_cupperplate,
+    create_location_index_from_copperplate,
 )
 
 
@@ -173,7 +173,7 @@ def Final_Energy_by_Carrier__Oil(
 
     Regionalization from the copperplate topology is performed by deriving a
     region code from demand- or production-bus names and applying
-    :func:`create_location_index_from_cupperplate` before regrouping to
+    :func:`create_location_index_from_copperplate` before regrouping to
     ``kwargs["groupby"]``.
 
     The renewable-oil fraction is computed per region as:
@@ -214,7 +214,7 @@ def Final_Energy_by_Carrier__Oil(
             bus.split(" ")[0] for bus in list(raw_rescom.index.get_level_values("bus1"))
         ]
         rescom = (
-            create_location_index_from_cupperplate(raw_rescom, usage_location)
+            create_location_index_from_copperplate(raw_rescom, usage_location)
             .groupby(kwargs["groupby"])
             .sum()
         )
@@ -256,7 +256,7 @@ def Final_Energy_by_Carrier__Oil(
         for bus in list(non_fossil_parts.index.get_level_values("bus0"))
     ]
 
-    non_fossil_parts = create_location_index_from_cupperplate(
+    non_fossil_parts = create_location_index_from_copperplate(
         non_fossil_parts, home_location
     )
     non_fossil_parts = non_fossil_parts.groupby(kwargs["groupby"]).sum()
@@ -284,7 +284,7 @@ def Final_Energy_by_Carrier__Oil(
         bus.split(" ")[0] for bus in list(all_oil.index.get_level_values("bus1"))
     ]
 
-    all_oil = create_location_index_from_cupperplate(all_oil, home_location)
+    all_oil = create_location_index_from_copperplate(all_oil, home_location)
     all_oil = all_oil.groupby(kwargs["groupby"]).sum()
 
     non_fossil_fraction = non_fossil_parts.div(all_oil)

--- a/pypsa_validation_processing/statistics_functions.py
+++ b/pypsa_validation_processing/statistics_functions.py
@@ -292,7 +292,7 @@ def Final_Energy_by_Carrier__Oil(
     non_fossil_fraction = non_fossil_fraction.mask(zero_oil, 1.0)
 
     non_fossil_fraction = non_fossil_fraction.clip(upper=1)  # TODO: Issue #53
-    non_fossil_fraction = non_fossil_fraction.rename(index=UNITS_MAPPING)
+    non_fossil_fraction = non_fossil_fraction.rename(index=UNITS_MAPPING, level="unit")
     non_fossil_fraction = non_fossil_fraction.groupby(
         kwargs["groupby"]
     ).mean()  # avoid double-indexing

--- a/pypsa_validation_processing/statistics_functions.py
+++ b/pypsa_validation_processing/statistics_functions.py
@@ -95,9 +95,58 @@ def Final_Energy_by_Carrier__Oil(
     n: pypsa.Network,
     aggregate_per_year: bool = True,
 ) -> pd.Series | pd.DataFrame:
-    """Docstring oil from cupperplate to AT"""
+    """Extract fossil final-energy oil demand from a PyPSA Network.
 
-    # TODO: calculate the fraction of renewable oil regionwise
+    Returns the final energy from oil carriers after removing an estimated
+    renewable-oil share.
+
+    Parameters
+    ----------
+    n : pypsa.Network
+        PyPSA network to process.
+    aggregate_per_year : bool, optional
+        If ``True`` (default), aggregate over all snapshots and return a
+        :class:`pandas.Series`. If ``False``, return a
+        :class:`pandas.DataFrame` with snapshots as columns.
+
+    Returns
+    -------
+    pd.Series | pd.DataFrame
+        Fossil oil final energy with MultiIndex including ``location`` and
+        ``unit``.
+        Returns data at regional level as provided by the PyPSA network.
+        Country-level aggregation is handled by
+        Network_Processor._aggregate_to_country() if configured.
+
+    Notes
+    -----
+    Total oil final energy is built from:
+    - agriculture machinery oil (Load),
+    - residential/commercial oil boiler demand (rural + urban decentral),
+    - land transport oil (Load).
+
+    ``naphtha for industry`` is intentionally excluded because it is treated
+    as non-energy use and therefore not part of Final Energy variables.
+
+    Regionalization from the copperplate topology is performed by deriving a
+    region code from demand- or production-bus names and applying
+    :func:`create_location_index_from_cupperplate` before regrouping to
+    ``kwargs["groupby"]``.
+
+    The renewable-oil fraction is computed per region as:
+
+    ``renewable oil production in region / total oil demand in region``.
+
+    Renewable production is based on supply from selected renewable-oil
+    carriers, while total oil demand is based on withdrawals from oil-using
+    carriers. If the fraction exceeds 1 (i.e., renewable production is larger
+    than regional oil demand), it is clipped to 1, so the fossil share becomes
+    zero in that region. Cross-regional export/import effects of renewable oil
+    are not represented in this statistic.
+
+    ``UNITS_MAPPING`` is applied inside this function to enable multiplication
+    with demand-side units of renewable-oil-fraction``.
+    """
 
     # Final Energy|Agricultur|Liquids - agriculture machinery oil
     agri = n.statistics.withdrawal(

--- a/pypsa_validation_processing/statistics_functions.py
+++ b/pypsa_validation_processing/statistics_functions.py
@@ -236,7 +236,7 @@ def Final_Energy_by_Carrier__Oil(
 
     total = pd.concat(series_list).groupby(kwargs["groupby"]).sum()
 
-    # non-fossil parts from renewable-gas production per location
+    # non-fossil parts from renewable-oil production per location
     # renewable oil production
     non_fossil_parts = n.statistics.supply(
         bus_carrier="oil",

--- a/pypsa_validation_processing/utils.py
+++ b/pypsa_validation_processing/utils.py
@@ -175,7 +175,7 @@ def get_energy_totals_domestic_share(
     return (domestic / (domestic + international)).values[0]
 
 
-def create_location_index_from_cupperplate(
+def create_location_index_from_copperplate(
     raw_input: pd.Series | pd.DataFrame, usage_location_list: list
 ):
     """

--- a/pypsa_validation_processing/utils.py
+++ b/pypsa_validation_processing/utils.py
@@ -128,6 +128,7 @@ UNITS_MAPPING = {
     "land transport": "MWh",
     "t_co2": "t",
     "": "",
+    "MWh": "MWh",
 }
 
 ## standards for statistics-functions

--- a/pypsa_validation_processing/utils.py
+++ b/pypsa_validation_processing/utils.py
@@ -172,3 +172,44 @@ def get_energy_totals_domestic_share(
     domestic = energy_totals[f"total domestic {kind}"]
     international = energy_totals[f"total international {kind}"]
     return (domestic / (domestic + international)).values[0]
+
+
+def create_location_index_from_cupperplate(
+    raw_input: pd.Series | pd.DataFrame, usage_location_list: list
+):
+    """
+    Replace the ``location`` level values of an indexed object.
+
+    This helper rebuilds the index of ``raw_input`` from its index frame and
+    overwrites the ``location`` column with values from
+    ``usage_location_list``. It is mainly used when location information from
+    a copperplate-carrier result must be mapped back to explicit regional labels.
+
+    Parameters
+    ----------
+    raw_input : pandas.Series or pandas.DataFrame
+        Input object with a (Multi)Index that includes a ``location`` level.
+        The function preserves data values and index level order/names.
+    usage_location_list : list
+        New location values to assign row-by-row. Must have the same length as
+        ``raw_input``.
+
+    Returns
+    -------
+    pandas.Series or pandas.DataFrame
+        A copy of ``raw_input`` with the same data and a rebuilt index where
+        the ``location`` level has been replaced.
+
+    Raises
+    ------
+    ValueError
+        If ``usage_location_list`` length does not match the number of rows, or
+        if the index cannot be reconstructed with the existing index names.
+    """
+    idx_df = raw_input.index.to_frame(index=False)
+    idx_df["location"] = pd.Index(usage_location_list).to_numpy()
+    idx_df
+    new_index = pd.MultiIndex.from_frame(idx_df, names=raw_input.index.names)
+    output = raw_input.copy()
+    output.index = new_index
+    return output

--- a/pypsa_validation_processing/utils.py
+++ b/pypsa_validation_processing/utils.py
@@ -209,7 +209,6 @@ def create_location_index_from_cupperplate(
     """
     idx_df = raw_input.index.to_frame(index=False)
     idx_df["location"] = pd.Index(usage_location_list).to_numpy()
-    idx_df
     new_index = pd.MultiIndex.from_frame(idx_df, names=raw_input.index.names)
     output = raw_input.copy()
     output.index = new_index

--- a/tests/test_statistics_functions.py
+++ b/tests/test_statistics_functions.py
@@ -7,6 +7,7 @@ import pytest
 
 from pypsa_validation_processing.statistics_functions import (
     Final_Energy_by_Carrier__Electricity,
+    Final_Energy_by_Carrier__Oil,
     Final_Energy_by_Sector__Industry,
     Final_Energy_by_Sector__Agriculture,
     Final_Energy_by_Sector__Transportation,
@@ -61,6 +62,223 @@ class TestFinalEnergyByCarrierElectricity:
             assert isinstance(result.index, pd.MultiIndex)
             assert result.index.names == ["location", "unit"]
             assert len(result) > 0
+
+
+# ---------------------------------------------------------------------------
+# Tests for Final_Energy_by_Carrier__Oil
+# ---------------------------------------------------------------------------
+
+
+class TestFinalEnergyByCarrierOil:
+    """Test suite for Final_Energy_by_Carrier__Oil function."""
+
+    class _OilStatisticsAccessor:
+        """Deterministic accessor tailored to oil final-energy tests."""
+
+        def __init__(self, *, rescom_empty: bool = False, all_oil_value: float = 200.0):
+            self.rescom_empty = rescom_empty
+            self.all_oil_value = all_oil_value
+
+        def _to_result(
+            self,
+            *,
+            index: pd.MultiIndex,
+            values: list[float],
+            aggregate_time: bool,
+        ) -> pd.Series | pd.DataFrame:
+            if aggregate_time:
+                return pd.Series(values, index=index, dtype=float)
+            timestamps = pd.date_range(
+                "2019-01-01", periods=4, freq="6h", name="snapshot"
+            )
+            return pd.DataFrame(
+                {ts: values for ts in timestamps}, index=index, dtype=float
+            )
+
+        def withdrawal(
+            self,
+            bus_carrier: str | None = None,
+            carrier: list[str] | str | None = None,
+            components: str | list[str] | None = None,
+            aggregate_time: bool = True,
+            groupby: list[str] | None = None,
+            at_port: str | None = None,
+            **kwargs: object,
+        ) -> pd.Series | pd.DataFrame:
+            if groupby is None:
+                groupby = ["location", "unit"]
+
+            # Agriculture and land-transport final demand (Load)
+            if carrier == "agriculture machinery oil" and components == "Load":
+                idx = pd.MultiIndex.from_tuples(
+                    [("AT1", "MWh_th")], names=["location", "unit"]
+                )
+                return self._to_result(
+                    index=idx, values=[100.0], aggregate_time=aggregate_time
+                )
+
+            if carrier == "land transport oil" and components == "Load":
+                idx = pd.MultiIndex.from_tuples(
+                    [("AT1", "MWh_th")], names=["location", "unit"]
+                )
+                return self._to_result(
+                    index=idx, values=[300.0], aggregate_time=aggregate_time
+                )
+
+            # Residential/commercial demand requiring copperplate -> location mapping via bus1
+            if (
+                bus_carrier == "oil"
+                and isinstance(carrier, list)
+                and set(carrier) == {"rural oil boiler", "urban decentral oil boiler"}
+            ):
+                idx_names = ["name", "bus", "carrier", "location", "unit", "bus1"]
+                if self.rescom_empty:
+                    empty_idx = pd.MultiIndex.from_arrays(
+                        [[] for _ in idx_names], names=idx_names
+                    )
+                    return self._to_result(
+                        index=empty_idx,
+                        values=[],
+                        aggregate_time=aggregate_time,
+                    )
+                idx = pd.MultiIndex.from_tuples(
+                    [
+                        (
+                            "rural_boiler_load",
+                            "AT1 oil",
+                            "rural oil boiler",
+                            "EU",
+                            "MWh_th",
+                            "AT1 oil",
+                        ),
+                        (
+                            "urban_boiler_load",
+                            "AT1 oil",
+                            "urban decentral oil boiler",
+                            "EU",
+                            "MWh_th",
+                            "AT1 oil",
+                        ),
+                    ],
+                    names=idx_names,
+                )
+                return self._to_result(
+                    index=idx,
+                    values=[50.0, 50.0],
+                    aggregate_time=aggregate_time,
+                )
+
+            # Total oil use denominator for non-fossil share
+            if (
+                bus_carrier == "oil"
+                and components == "Link"
+                and at_port == "bus0"
+                and groupby == ["bus1", "carrier", "location", "unit"]
+            ):
+                idx = pd.MultiIndex.from_tuples(
+                    [
+                        (
+                            "AT1 oil",
+                            "land transport oil",
+                            "EU",
+                            "MWh_th",
+                        )
+                    ],
+                    names=["bus1", "carrier", "location", "unit"],
+                )
+                return self._to_result(
+                    index=idx,
+                    values=[self.all_oil_value],
+                    aggregate_time=aggregate_time,
+                )
+
+            raise AssertionError(
+                f"Unexpected withdrawal call: bus_carrier={bus_carrier}, carrier={carrier}, components={components}, groupby={groupby}, at_port={at_port}"
+            )
+
+        def supply(
+            self,
+            bus_carrier: str | None = None,
+            carrier: list[str] | str | None = None,
+            at_port: str | None = None,
+            components: str | list[str] | None = None,
+            groupby: list[str] | None = None,
+            aggregate_time: bool = True,
+            **kwargs: object,
+        ) -> pd.Series | pd.DataFrame:
+            if (
+                bus_carrier == "oil"
+                and components == "Link"
+                and at_port == "bus1"
+                and groupby == ["name", "bus", "carrier", "location", "unit", "bus0"]
+            ):
+                idx = pd.MultiIndex.from_tuples(
+                    [
+                        (
+                            "renewable_oil_link",
+                            "AT1 oil",
+                            "biomass to liquid",
+                            "EU",
+                            "MWh_th",
+                            "AT1 oil",
+                        )
+                    ],
+                    names=["name", "bus", "carrier", "location", "unit", "bus0"],
+                )
+                return self._to_result(
+                    index=idx, values=[500.0], aggregate_time=aggregate_time
+                )
+
+            raise AssertionError(
+                f"Unexpected supply call: bus_carrier={bus_carrier}, carrier={carrier}, components={components}, groupby={groupby}, at_port={at_port}"
+            )
+
+    class _OilNetwork:
+        """Minimal network object exposing only the statistics accessor."""
+
+        def __init__(self, *, rescom_empty: bool = False, all_oil_value: float = 200.0):
+            self.statistics = TestFinalEnergyByCarrierOil._OilStatisticsAccessor(
+                rescom_empty=rescom_empty,
+                all_oil_value=all_oil_value,
+            )
+
+    def test_clips_non_fossil_share_above_one_to_zero_fossil(self):
+        """Renewable oil production above total demand should yield zero fossil oil."""
+        result = Final_Energy_by_Carrier__Oil(self._OilNetwork())
+
+        assert isinstance(result, pd.Series)
+        assert isinstance(result.index, pd.MultiIndex)
+        assert result.index.names == ["location", "unit"]
+        assert result.loc[("AT1", "MWh")] == pytest.approx(0.0)
+
+    def test_handles_empty_rescom_without_failing(self):
+        """Function should work even when residential/commercial oil demand is empty."""
+        result = Final_Energy_by_Carrier__Oil(self._OilNetwork(rescom_empty=True))
+
+        assert isinstance(result, pd.Series)
+        assert isinstance(result.index, pd.MultiIndex)
+        assert result.index.names == ["location", "unit"]
+        # non-fossil fraction is clipped to 1, so fossil share remains zero.
+        assert result.loc[("AT1", "MWh")] == pytest.approx(0.0)
+
+    def test_handles_zero_total_oil_demand_denominator(self):
+        """Division by zero in non-fossil share denominator should not crash."""
+        result = Final_Energy_by_Carrier__Oil(self._OilNetwork(all_oil_value=0.0))
+
+        assert isinstance(result, pd.Series)
+        assert result.loc[("AT1", "MWh")] == pytest.approx(0.0)
+
+    def test_returns_dataframe_for_aggregate_per_year_false(self):
+        """Function should return a timeseries DataFrame for aggregate_per_year=False."""
+        result = Final_Energy_by_Carrier__Oil(
+            self._OilNetwork(),
+            aggregate_per_year=False,
+        )
+
+        assert isinstance(result, pd.DataFrame)
+        assert isinstance(result.index, pd.MultiIndex)
+        assert result.index.names == ["location", "unit"]
+        assert isinstance(result.columns, pd.DatetimeIndex)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_statistics_functions.py
+++ b/tests/test_statistics_functions.py
@@ -231,9 +231,18 @@ class TestFinalEnergyByCarrierOil:
     class _OilStatisticsAccessor:
         """Deterministic accessor tailored to oil final-energy tests."""
 
-        def __init__(self, *, rescom_empty: bool = False, all_oil_value: float = 200.0):
+        def __init__(
+            self,
+            *,
+            rescom_empty: bool = False,
+            all_oil_value: float = 200.0,
+            all_oil_empty: bool = False,
+            non_fossil_empty: bool = False,
+        ):
             self.rescom_empty = rescom_empty
             self.all_oil_value = all_oil_value
+            self.all_oil_empty = all_oil_empty
+            self.non_fossil_empty = non_fossil_empty
 
         def _to_result(
             self,
@@ -331,6 +340,16 @@ class TestFinalEnergyByCarrierOil:
                 and at_port == "bus0"
                 and groupby == ["bus1", "carrier", "location", "unit"]
             ):
+                if self.all_oil_empty:
+                    empty_idx = pd.MultiIndex.from_arrays(
+                        [[], [], [], []],
+                        names=["bus1", "carrier", "location", "unit"],
+                    )
+                    return self._to_result(
+                        index=empty_idx,
+                        values=[],
+                        aggregate_time=aggregate_time,
+                    )
                 idx = pd.MultiIndex.from_tuples(
                     [
                         (
@@ -368,6 +387,16 @@ class TestFinalEnergyByCarrierOil:
                 and at_port == "bus1"
                 and groupby == ["name", "bus", "carrier", "location", "unit", "bus0"]
             ):
+                if self.non_fossil_empty:
+                    empty_idx = pd.MultiIndex.from_arrays(
+                        [[], [], [], [], [], []],
+                        names=["name", "bus", "carrier", "location", "unit", "bus0"],
+                    )
+                    return self._to_result(
+                        index=empty_idx,
+                        values=[],
+                        aggregate_time=aggregate_time,
+                    )
                 idx = pd.MultiIndex.from_tuples(
                     [
                         (
@@ -392,10 +421,19 @@ class TestFinalEnergyByCarrierOil:
     class _OilNetwork:
         """Minimal network object exposing only the statistics accessor."""
 
-        def __init__(self, *, rescom_empty: bool = False, all_oil_value: float = 200.0):
+        def __init__(
+            self,
+            *,
+            rescom_empty: bool = False,
+            all_oil_value: float = 200.0,
+            all_oil_empty: bool = False,
+            non_fossil_empty: bool = False,
+        ):
             self.statistics = TestFinalEnergyByCarrierOil._OilStatisticsAccessor(
                 rescom_empty=rescom_empty,
                 all_oil_value=all_oil_value,
+                all_oil_empty=all_oil_empty,
+                non_fossil_empty=non_fossil_empty,
             )
 
     def test_clips_non_fossil_share_above_one_to_zero_fossil(self):
@@ -423,6 +461,29 @@ class TestFinalEnergyByCarrierOil:
 
         assert isinstance(result, pd.Series)
         assert result.loc[("AT1", "MWh")] == pytest.approx(0.0)
+
+    def test_no_renewable_oil_production_fossil_equals_total(self):
+        """Without renewable oil supply, fossil oil should equal total oil demand."""
+        result = Final_Energy_by_Carrier__Oil(self._OilNetwork(non_fossil_empty=True))
+
+        assert isinstance(result, pd.Series)
+        assert isinstance(result.index, pd.MultiIndex)
+        assert result.index.names == ["location", "unit"]
+        assert not result.isna().any()
+        # 100 (agri) + 100 (res/com) + 300 (transport) = 500
+        assert result.loc[("AT1", "MWh")] == pytest.approx(500.0)
+
+    def test_handles_empty_all_oil_without_failing(self):
+        """Function should work when total oil-withdrawal denominator is empty."""
+        result = Final_Energy_by_Carrier__Oil(
+            self._OilNetwork(all_oil_empty=True, non_fossil_empty=True)
+        )
+
+        assert isinstance(result, pd.Series)
+        assert isinstance(result.index, pd.MultiIndex)
+        assert result.index.names == ["location", "unit"]
+        assert not result.isna().any()
+        assert (result == 0.0).all()
 
     def test_returns_dataframe_for_aggregate_per_year_false(self):
         """Function should return a timeseries DataFrame for aggregate_per_year=False."""


### PR DESCRIPTION
Add variable function for IAMC-variable **Final Energy [by Carrier]|Oil**

### Open To Dos:
- [x] add a comprehensive docstring to your function 
- [x] add renewable-oil fraction to statistics-output
- [x] Add a testing routine for your Function to `tests/` - stick to the [testing-README](https://github.com/maxnutz/pypsa_validation_processing/blob/main/tests/README.md)
- [x] make sure, that the newest version of main is merged into your feature Branch 


### Validation
| variable | PyPSA-output | IAMC Energy Balance | 🟢 🟡 🟠 🔴 |
| -- | -- | -- | -- |
| Final Energy [by Carrier]\|Oil | 343701 | 354445 | :yellow_circle: excludes naphtha for industry |

- energy balance evaluation does NOT include biofuel parts for *oil*
- calculation of renewable-oil-fraction includes naphtha-for-industry as carrier.

#### Concerning Naphtha for industry
- in our IAMC-variable definition, _energy consumption_ is directly included, excluding non-energy-demands. 
- energy balance FE_E does NOT include naphtha for industrial processes in Final Energy (there is an extra _non-energy-use_ accounting)
- in pypsa-eur, demand from naphtha for industry is integrated from [JRC-IDEES-Database](https://publications.jrc.ec.europa.eu/repository/handle/JRC137809), including Naphtha as Fuel for "Chemical industry > Basic chemicals" and in their report, they include following statement concerning that subsector: 
  > Process-related non-energy use, which is modelled for the Basic chemicals subsector to
distinguish the consumption of chemical feedstocks, given that this consumption may be
subject to significantly different dynamics than energy use. 
- and, Naphtha is an assimilation of different fuel oils and other liquids used in chemical industry (see function `chemicals_industry()` in `build_industry_sector_ratios.py`)
- for the fraction factor fossil-oil - non-fossil-oil, naphtha is included, as it covers part of the demand, non-fossil-oil production is used for. 

#### Concerning fraction of non-fossil oil
Calculating the fraction of non-fossil oil is a first-guess code to likely be refactored in the future. For excluding non-fossil oil parts from statistics, a fraction of fossil-oil to non-fossil-oil is calculated using 2 meta-variables:
- demand of oil per region
- production of renewable oil per region

mixing demand and supply variables. Renewable oil flows are not included in this statistics and so, for regions with low oil demand and high production rates of renewable oil, this can lead to a renewable-oil-factor greater 1. Currently, these factors are clipped to 1, additional renewable oil production is therefore "lost".

**Problem**: renewable oil production exceeding the oil consumption of the respective region is lost, statistics are not fully consistent. This applies especially for country-wise aggregation, where renewable-oil-fraction is therefore underestimated. Problem will be covered in Issue #53 


---
## Summary by Sourcery

Add support for computing IAMC variable 'Final Energy [by Carrier]|Oil' and map it into the default statistics configuration.

New Features:
- Introduce Final_Energy_by_Carrier__Oil statistics function aggregating oil-based final energy demand across sectors.
- Expose the new oil final energy variable in the default IAMC mapping configuration.

Enhancements:
- Add utility helper to remap copperplate-based location indices to regional location labels in statistics outputs.

## Summary by Sourcery

Add statistics support for fossil final energy oil demand and ensure it is robust and region-aware.

New Features:
- Introduce Final_Energy_by_Carrier__Oil statistics function to compute fossil final-energy oil demand by region with renewable share adjustment.

Enhancements:
- Add create_location_index_from_cupperplate utility to remap copperplate-based results to regional location indices.
- Extend unit mapping to cover plain MWh entries.

Tests:
- Add a dedicated test suite for Final_Energy_by_Carrier__Oil covering edge cases such as empty demand, zero denominators, and timeseries output.