### PR TITLE
Main hot fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ Thumbs.db
 
 # Data and output (non-versioned)
 resources/
+outputs/
 sister_packages/*
 !sister_packages/AGENTS.md
 *.xlsx

--- a/pypsa_validation_processing/statistics_functions.py
+++ b/pypsa_validation_processing/statistics_functions.py
@@ -434,11 +434,11 @@ def Final_Energy_by_Carrier__Natural_Gas(
     non_fossil_fraction = non_fossil_fraction.rename(index=UNITS_MAPPING)
 
     # Final Energy|Residential and Commercial|Natural Gas - urban decentral gas boiler
-    rescom = n.statistics.withdrawal(
-        bus_carrier="gas",
+    rescom_gas = n.statistics.energy_balance(
         carrier=["urban decentral gas boiler", "rural gas boiler"],
         components="Link",
-        aggregate_time=aggregate_per_year,
+        at_port="bus0",  # count gas not heat
+        groupby_time=aggregate_per_year,
         **kwargs,
     )
 
@@ -461,7 +461,7 @@ def Final_Energy_by_Carrier__Natural_Gas(
     energy_fraction_industry_gas = fc_energy / (fc_energy + fc_noenergy)
     industry = industry.mul(energy_fraction_industry_gas)
 
-    series_list = [rescom, industry]
+    series_list = [rescom_gas, industry]
     series_list = [series for series in series_list if not series.empty]
 
     if not series_list:

--- a/pypsa_validation_processing/statistics_functions.py
+++ b/pypsa_validation_processing/statistics_functions.py
@@ -81,13 +81,13 @@ def Final_Energy_by_Carrier__Electricity(
     agri = n.statistics.withdrawal(
         carrier=["agriculture electricity", "agriculture machinery electric"],
         components="Load",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs,
     )
 
     # get Final Energy|Residential and Commercial|Electricity
     lv = n.statistics.withdrawal(
-        bus_carrier="low voltage", aggregate_time=aggregate_per_year, **kwargs_filtering
+        bus_carrier="low voltage", groupby_time=aggregate_per_year, **kwargs_filtering
     )
     forbidden_parts = [
         "urban central",
@@ -106,7 +106,7 @@ def Final_Energy_by_Carrier__Electricity(
         bus_carrier="low voltage",
         carrier="BEV charger",
         components="Link",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs,
     )
 
@@ -114,7 +114,7 @@ def Final_Energy_by_Carrier__Electricity(
     industry = n.statistics.withdrawal(
         carrier="industry electricity",
         components="Load",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs,
     )
 
@@ -123,7 +123,7 @@ def Final_Energy_by_Carrier__Electricity(
         bus_carrier="AC",
         carrier="DAC",
         components="Link",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs,
     )
 
@@ -171,7 +171,7 @@ def Final_Energy_by_Carrier__Coal(
         bus_carrier="coal for industry",
         carrier="coal for industry",
         components="Load",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs,
     )
     return industry
@@ -238,7 +238,7 @@ def Final_Energy_by_Carrier__Oil(
     agri = n.statistics.withdrawal(
         carrier="agriculture machinery oil",
         components="Load",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs,
     )
 
@@ -247,7 +247,7 @@ def Final_Energy_by_Carrier__Oil(
         bus_carrier="oil",
         carrier=["rural oil boiler", "urban decentral oil boiler"],
         groupby=kwargs_filtering["groupby"] + ["bus1"],
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
     )
     if raw_rescom.empty:
         rescom = raw_rescom
@@ -266,7 +266,7 @@ def Final_Energy_by_Carrier__Oil(
     transpo = n.statistics.withdrawal(
         carrier="land transport oil",
         components="Load",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs,
     )
 
@@ -404,7 +404,7 @@ def Final_Energy_by_Carrier__Natural_Gas(
         ],
         at_port="bus1",
         components="Link",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs,
     )
 
@@ -412,7 +412,7 @@ def Final_Energy_by_Carrier__Natural_Gas(
     all_gas = n.statistics.withdrawal(
         bus_carrier="gas",
         components="Link",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs_filtering,
     )
     all_gas.index.get_level_values("carrier").unique()
@@ -447,7 +447,7 @@ def Final_Energy_by_Carrier__Natural_Gas(
         bus_carrier="gas for industry",
         carrier=["gas for industry", "gas for industry CC"],
         components="Load",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs,
     )
 
@@ -553,7 +553,7 @@ def Final_Energy_by_Sector__Transportation(
         bus_carrier="low voltage",
         carrier="BEV charger",
         components="Link",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs,
     ).mul(
         1 / eff
@@ -563,7 +563,7 @@ def Final_Energy_by_Sector__Transportation(
     h2 = n.statistics.withdrawal(
         carrier="land transport fuel cell",
         components="Load",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs,
     )
 
@@ -572,7 +572,7 @@ def Final_Energy_by_Sector__Transportation(
         n.statistics.withdrawal(
             carrier="kerosene for aviation",
             components="Load",
-            aggregate_time=aggregate_per_year,
+            groupby_time=aggregate_per_year,
             **kwargs,
         )
         * domestic_aviation_fraction
@@ -582,7 +582,7 @@ def Final_Energy_by_Sector__Transportation(
         n.statistics.withdrawal(
             carrier=["shipping oil", "shipping methanol"],
             components="Load",
-            aggregate_time=aggregate_per_year,
+            groupby_time=aggregate_per_year,
             **kwargs,
         )
         * domestic_navigation_fraction
@@ -591,7 +591,7 @@ def Final_Energy_by_Sector__Transportation(
     land_transport_liquids = n.statistics.withdrawal(
         carrier="land transport oil",
         components="Load",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs,
     )
 
@@ -856,7 +856,7 @@ def Final_Energy_by_Sector__Residential_and_Commercial(
         bus_carrier="oil",
         carrier=["rural oil boiler", "urban decentral oil boiler"],
         groupby=kwargs_filtering["groupby"] + ["bus1"],
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
     )
     if raw_rescom.empty:
         rescom_liquids = raw_rescom

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,24 +127,19 @@ class MockStatisticsAccessor:
         bus_carrier: str | None = None,
         carrier: list[str] | str | None = None,
         components: str | list[str] | None = None,
-        aggregate_time: bool = True,
+        groupby_time: bool = True,
         groupby: list[str] | None = None,
         nice_names: bool | None = None,
         **kwargs: object,
     ) -> pd.Series | pd.DataFrame:
-        """Mock withdrawal method forwarding to energy_balance.
-
-        PyPSA's statistics.withdrawal uses ``aggregate_time`` while
-        ``energy_balance`` uses ``groupby_time``. This adapter keeps tests
-        compatible with either call style.
-        """
+        """Mock withdrawal method forwarding to energy_balance."""
         return self.energy_balance(
             bus_carrier=bus_carrier,
             carrier=carrier,
             components=components,
             groupby=groupby,
             direction="withdrawal",
-            groupby_time=aggregate_time,
+            groupby_time=groupby_time,
             nice_names=nice_names,
             **kwargs,
         )

--- a/tests/test_statistics_functions.py
+++ b/tests/test_statistics_functions.py
@@ -51,7 +51,7 @@ class TestFinalEnergyByCarrierElectricity:
             bus_carrier: str | None = None,
             carrier: list[str] | str | None = None,
             components: str | list[str] | None = None,
-            aggregate_time: bool = True,
+            groupby_time: bool = False,
             groupby: list[str] | None = None,
             nice_names: bool | None = None,
             **_: object,
@@ -61,7 +61,7 @@ class TestFinalEnergyByCarrierElectricity:
                     "bus_carrier": bus_carrier,
                     "carrier": carrier,
                     "components": components,
-                    "aggregate_time": aggregate_time,
+                    "groupby_time": groupby_time,
                     "groupby": groupby,
                     "nice_names": nice_names,
                 }
@@ -250,9 +250,9 @@ class TestFinalEnergyByCarrierOil:
             *,
             index: pd.MultiIndex,
             values: list[float],
-            aggregate_time: bool,
+            groupby_time: bool,
         ) -> pd.Series | pd.DataFrame:
-            if aggregate_time:
+            if groupby_time:
                 return pd.Series(values, index=index, dtype=float)
             timestamps = pd.date_range(
                 "2019-01-01", periods=4, freq="6h", name="snapshot"
@@ -266,7 +266,7 @@ class TestFinalEnergyByCarrierOil:
             bus_carrier: str | None = None,
             carrier: list[str] | str | None = None,
             components: str | list[str] | None = None,
-            aggregate_time: bool = True,
+            groupby_time: bool = True,
             groupby: list[str] | None = None,
             at_port: str | None = None,
             **kwargs: object,
@@ -280,7 +280,7 @@ class TestFinalEnergyByCarrierOil:
                     [("AT1", "MWh_th")], names=["location", "unit"]
                 )
                 return self._to_result(
-                    index=idx, values=[100.0], aggregate_time=aggregate_time
+                    index=idx, values=[100.0], groupby_time=groupby_time
                 )
 
             if carrier == "land transport oil" and components == "Load":
@@ -288,7 +288,7 @@ class TestFinalEnergyByCarrierOil:
                     [("AT1", "MWh_th")], names=["location", "unit"]
                 )
                 return self._to_result(
-                    index=idx, values=[300.0], aggregate_time=aggregate_time
+                    index=idx, values=[300.0], groupby_time=groupby_time
                 )
 
             # Residential/commercial demand requiring copperplate -> location mapping via bus1
@@ -305,7 +305,7 @@ class TestFinalEnergyByCarrierOil:
                     return self._to_result(
                         index=empty_idx,
                         values=[],
-                        aggregate_time=aggregate_time,
+                        groupby_time=groupby_time,
                     )
                 idx = pd.MultiIndex.from_tuples(
                     [
@@ -331,7 +331,7 @@ class TestFinalEnergyByCarrierOil:
                 return self._to_result(
                     index=idx,
                     values=[50.0, 50.0],
-                    aggregate_time=aggregate_time,
+                    groupby_time=groupby_time,
                 )
 
             # Total oil use denominator for non-fossil share
@@ -349,7 +349,7 @@ class TestFinalEnergyByCarrierOil:
                     return self._to_result(
                         index=empty_idx,
                         values=[],
-                        aggregate_time=aggregate_time,
+                        groupby_time=groupby_time,
                     )
                 idx = pd.MultiIndex.from_tuples(
                     [
@@ -365,7 +365,7 @@ class TestFinalEnergyByCarrierOil:
                 return self._to_result(
                     index=idx,
                     values=[self.all_oil_value],
-                    aggregate_time=aggregate_time,
+                    groupby_time=groupby_time,
                 )
 
             raise AssertionError(
@@ -379,7 +379,7 @@ class TestFinalEnergyByCarrierOil:
             at_port: str | None = None,
             components: str | list[str] | None = None,
             groupby: list[str] | None = None,
-            aggregate_time: bool = True,
+            groupby_time: bool = True,
             **kwargs: object,
         ) -> pd.Series | pd.DataFrame:
             if (
@@ -396,7 +396,7 @@ class TestFinalEnergyByCarrierOil:
                     return self._to_result(
                         index=empty_idx,
                         values=[],
-                        aggregate_time=aggregate_time,
+                        groupby_time=groupby_time,
                     )
                 idx = pd.MultiIndex.from_tuples(
                     [
@@ -412,7 +412,7 @@ class TestFinalEnergyByCarrierOil:
                     names=["name", "bus", "carrier", "location", "unit", "bus0"],
                 )
                 return self._to_result(
-                    index=idx, values=[500.0], aggregate_time=aggregate_time
+                    index=idx, values=[500.0], groupby_time=groupby_time
                 )
 
             raise AssertionError(
@@ -555,7 +555,7 @@ class TestFinalEnergyByCarrierNaturalGas:
             carrier: list[str] | str | None = None,
             at_port: str | None = None,
             components: str | list[str] | None = None,
-            aggregate_time: bool = True,
+            groupby_time: bool = True,
             groupby: list[str] | None = None,
             nice_names: bool | None = None,
             **_: object,
@@ -572,10 +572,10 @@ class TestFinalEnergyByCarrierNaturalGas:
                 if self.scenario in ("no_gas", "no_renewable"):
                     return self._empty_series(groupby)
                 if self.scenario == "no_fossil":
-                    if aggregate_time:
+                    if groupby_time:
                         return self._series_from_groupby(groupby, [100.0])
                     return self._dataframe_from_groupby(groupby, [100.0, 100.0])
-                if aggregate_time:
+                if groupby_time:
                     return self._series_from_groupby(groupby, [20.0])
                 return self._dataframe_from_groupby(groupby, [20.0, 20.0])
 
@@ -586,7 +586,7 @@ class TestFinalEnergyByCarrierNaturalGas:
             bus_carrier: str | None = None,
             carrier: list[str] | str | None = None,
             components: str | list[str] | None = None,
-            aggregate_time: bool = True,
+            groupby_time: bool = True,
             groupby: list[str] | None = None,
             nice_names: bool | None = None,
             **_: object,
@@ -621,7 +621,7 @@ class TestFinalEnergyByCarrierNaturalGas:
                     ],
                     names=groupby,
                 )
-                if aggregate_time:
+                if groupby_time:
                     return pd.Series([100.0, 900.0], index=index, dtype=float)
                 columns = pd.Index(
                     pd.to_datetime(["2019-01-01", "2019-01-02"]), name="snapshot"
@@ -637,7 +637,7 @@ class TestFinalEnergyByCarrierNaturalGas:
             ):
                 if self.scenario == "no_gas":
                     return self._empty_series(groupby)
-                if aggregate_time:
+                if groupby_time:
                     return self._series_from_groupby(groupby, [40.0])
                 return self._dataframe_from_groupby(groupby, [40.0, 40.0])
 
@@ -648,7 +648,7 @@ class TestFinalEnergyByCarrierNaturalGas:
             ):
                 if self.scenario == "no_gas":
                     return self._empty_series(groupby)
-                if aggregate_time:
+                if groupby_time:
                     return self._series_from_groupby(groupby, [60.0])
                 return self._dataframe_from_groupby(groupby, [60.0, 60.0])
 
@@ -747,9 +747,9 @@ class TestFinalEnergyByCarrierOil:
             *,
             index: pd.MultiIndex,
             values: list[float],
-            aggregate_time: bool,
+            groupby_time: bool,
         ) -> pd.Series | pd.DataFrame:
-            if aggregate_time:
+            if groupby_time:
                 return pd.Series(values, index=index, dtype=float)
             timestamps = pd.date_range(
                 "2019-01-01", periods=4, freq="6h", name="snapshot"
@@ -763,7 +763,7 @@ class TestFinalEnergyByCarrierOil:
             bus_carrier: str | None = None,
             carrier: list[str] | str | None = None,
             components: str | list[str] | None = None,
-            aggregate_time: bool = True,
+            groupby_time: bool = True,
             groupby: list[str] | None = None,
             at_port: str | None = None,
             **kwargs: object,
@@ -777,7 +777,7 @@ class TestFinalEnergyByCarrierOil:
                     [("AT1", "MWh_th")], names=["location", "unit"]
                 )
                 return self._to_result(
-                    index=idx, values=[100.0], aggregate_time=aggregate_time
+                    index=idx, values=[100.0], groupby_time=groupby_time
                 )
 
             if carrier == "land transport oil" and components == "Load":
@@ -785,7 +785,7 @@ class TestFinalEnergyByCarrierOil:
                     [("AT1", "MWh_th")], names=["location", "unit"]
                 )
                 return self._to_result(
-                    index=idx, values=[300.0], aggregate_time=aggregate_time
+                    index=idx, values=[300.0], groupby_time=groupby_time
                 )
 
             # Residential/commercial demand requiring copperplate -> location mapping via bus1
@@ -802,7 +802,7 @@ class TestFinalEnergyByCarrierOil:
                     return self._to_result(
                         index=empty_idx,
                         values=[],
-                        aggregate_time=aggregate_time,
+                        groupby_time=groupby_time,
                     )
                 idx = pd.MultiIndex.from_tuples(
                     [
@@ -828,7 +828,7 @@ class TestFinalEnergyByCarrierOil:
                 return self._to_result(
                     index=idx,
                     values=[50.0, 50.0],
-                    aggregate_time=aggregate_time,
+                    groupby_time=groupby_time,
                 )
 
             # Total oil use denominator for non-fossil share
@@ -846,7 +846,7 @@ class TestFinalEnergyByCarrierOil:
                     return self._to_result(
                         index=empty_idx,
                         values=[],
-                        aggregate_time=aggregate_time,
+                        groupby_time=groupby_time,
                     )
                 idx = pd.MultiIndex.from_tuples(
                     [
@@ -862,7 +862,7 @@ class TestFinalEnergyByCarrierOil:
                 return self._to_result(
                     index=idx,
                     values=[self.all_oil_value],
-                    aggregate_time=aggregate_time,
+                    groupby_time=groupby_time,
                 )
 
             raise AssertionError(
@@ -876,7 +876,7 @@ class TestFinalEnergyByCarrierOil:
             at_port: str | None = None,
             components: str | list[str] | None = None,
             groupby: list[str] | None = None,
-            aggregate_time: bool = True,
+            groupby_time: bool = True,
             **kwargs: object,
         ) -> pd.Series | pd.DataFrame:
             if (
@@ -893,7 +893,7 @@ class TestFinalEnergyByCarrierOil:
                     return self._to_result(
                         index=empty_idx,
                         values=[],
-                        aggregate_time=aggregate_time,
+                        groupby_time=groupby_time,
                     )
                 idx = pd.MultiIndex.from_tuples(
                     [
@@ -909,7 +909,7 @@ class TestFinalEnergyByCarrierOil:
                     names=["name", "bus", "carrier", "location", "unit", "bus0"],
                 )
                 return self._to_result(
-                    index=idx, values=[500.0], aggregate_time=aggregate_time
+                    index=idx, values=[500.0], groupby_time=groupby_time
                 )
 
             raise AssertionError(
@@ -1029,7 +1029,7 @@ class TestFinalEnergyByCarrierCoal:
             bus_carrier: str | None = None,
             carrier: list[str] | str | None = None,
             components: str | list[str] | None = None,
-            aggregate_time: bool = True,
+            groupby_time: bool = True,
             groupby: list[str] | None = None,
             nice_names: bool | None = None,
             **_: object,
@@ -1039,7 +1039,7 @@ class TestFinalEnergyByCarrierCoal:
                     "bus_carrier": bus_carrier,
                     "carrier": carrier,
                     "components": components,
-                    "aggregate_time": aggregate_time,
+                    "groupby_time": groupby_time,
                     "groupby": groupby,
                     "nice_names": nice_names,
                 }
@@ -1365,7 +1365,7 @@ class TestFinalEnergyBySectorResidentialAndCommercial:
             bus_carrier: str | None = None,
             carrier: list[str] | str | None = None,
             components: str | list[str] | None = None,
-            aggregate_time: bool = True,
+            groupby_time: bool = True,
             groupby: list[str] | None = None,
             **kwargs: object,
         ) -> pd.Series | pd.DataFrame:
@@ -1376,7 +1376,7 @@ class TestFinalEnergyBySectorResidentialAndCommercial:
                 components=components,
                 groupby=groupby,
                 direction="withdrawal",
-                groupby_time=aggregate_time,
+                groupby_time=groupby_time,
                 **kwargs,
             )
 

--- a/tests/test_statistics_functions.py
+++ b/tests/test_statistics_functions.py
@@ -512,6 +512,7 @@ class TestFinalEnergyByCarrierNaturalGas:
 
         def __init__(self, scenario: str = "mixed"):
             self.scenario = scenario
+            self.calls: list[dict[str, object]] = []
 
         @staticmethod
         def _empty_series(groupby: list[str]) -> pd.Series:
@@ -578,6 +579,45 @@ class TestFinalEnergyByCarrierNaturalGas:
                 if groupby_time:
                     return self._series_from_groupby(groupby, [20.0])
                 return self._dataframe_from_groupby(groupby, [20.0, 20.0])
+
+            return self._empty_series(groupby)
+
+        def energy_balance(
+            self,
+            bus_carrier: str | None = None,
+            carrier: list[str] | str | None = None,
+            components: str | list[str] | None = None,
+            at_port: str | list[str] | None = None,
+            # groupby_time: bool = True,
+            groupby: list[str] | None = None,
+            groupby_time: bool | None = None,
+            **_: object,
+        ) -> pd.Series | pd.DataFrame:
+            if groupby is None:
+                groupby = ["location", "unit"]
+
+            self.calls.append(
+                {
+                    "bus_carrier": bus_carrier,
+                    "carrier": carrier,
+                    "components": components,
+                    "at_port": at_port,
+                    "groupby_time": groupby_time,
+                    "groupby": groupby,
+                    "groupby_time": groupby_time,
+                }
+            )
+
+            if (
+                carrier == ["urban decentral gas boiler", "rural gas boiler"]
+                and components == "Link"
+                and at_port == "bus0"
+            ):
+                if self.scenario == "no_gas":
+                    return self._empty_series(groupby)
+                if groupby_time:
+                    return self._series_from_groupby(groupby, [40.0])
+                return self._dataframe_from_groupby(groupby, [40.0, 40.0])
 
             return self._empty_series(groupby)
 
@@ -692,6 +732,19 @@ class TestFinalEnergyByCarrierNaturalGas:
         )
         # total=100, non-fossil share=20/100, result=100*(1-0.2)=80
         assert result.loc[("AT1", "MWh")] == pytest.approx(77.1322, 0.1)
+
+    def test_uses_energy_balance_for_residential_and_commercial_gas(self):
+        """Residential/commercial gas demand is now taken from energy_balance."""
+        network = self._natural_gas_network("mixed")
+
+        _ = Final_Energy_by_Carrier__Natural_Gas(network)
+
+        assert any(
+            call["carrier"] == ["urban decentral gas boiler", "rural gas boiler"]
+            and call["components"] == "Link"
+            and call["at_port"] == "bus0"
+            for call in network.statistics.calls
+        )
 
     def test_edge_case_no_gas_returns_empty_series(self):
         """No gas usage and no gas demand should return an empty result."""

--- a/tests/test_statistics_functions.py
+++ b/tests/test_statistics_functions.py
@@ -588,9 +588,8 @@ class TestFinalEnergyByCarrierNaturalGas:
             carrier: list[str] | str | None = None,
             components: str | list[str] | None = None,
             at_port: str | list[str] | None = None,
-            # groupby_time: bool = True,
             groupby: list[str] | None = None,
-            groupby_time: bool | None = None,
+            groupby_time: bool = True,
             **_: object,
         ) -> pd.Series | pd.DataFrame:
             if groupby is None:


### PR DESCRIPTION
- update .gitignore-file
- major debug: replace parameter aggregate_time with groupby_time, as aggregate_time is NOT a valid parameter in pypsa-statistics
- uniform calculation of gas usage in sector rescom to count for gas in heating systems, not for heat.

## Summary by Sourcery

Align statistics helpers and processing with PyPSA’s time-grouping API and correct natural gas accounting for residential/commercial demand.

Bug Fixes:
- Replace use of the invalid aggregate_time parameter with groupby_time across statistics helpers and processing functions.
- Compute residential and commercial natural gas demand from gas input (bus0) via energy_balance instead of from heat output.

Enhancements:
- Introduce an energy_balance helper on the natural gas statistics accessor that records calls and supports grouped or time-resolved outputs.

Tests:
- Extend natural gas statistics tests to verify that residential/commercial gas demand is sourced via energy_balance and to cover the new groupby_time behavior.

Chores:
- Update test mocks and adapters to match the current PyPSA statistics API and refresh .gitignore entries.