### PR TITLE
14 new variable statistics final energy by sectorresidential and commercial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ Thumbs.db
 
 # Data and output (non-versioned)
 resources/
+outputs/
 sister_packages/*
 !sister_packages/AGENTS.md
 *.xlsx

--- a/pypsa_validation_processing/configs/mapping.default.yaml
+++ b/pypsa_validation_processing/configs/mapping.default.yaml
@@ -12,3 +12,4 @@ Final Energy [by Carrier]|Oil: Final_Energy_by_Carrier__Oil
 Final Energy [by Sector]|Transportation: Final_Energy_by_Sector__Transportation
 Final Energy [by Sector]|Industry: Final_Energy_by_Sector__Industry
 Final Energy [by Sector]|Agriculture: Final_Energy_by_Sector__Agriculture
+Final Energy [by Sector]|Residential and Commercial: Final_Energy_by_Sector__Residential_and_Commercial

--- a/pypsa_validation_processing/statistics_functions.py
+++ b/pypsa_validation_processing/statistics_functions.py
@@ -767,3 +767,131 @@ def Final_Energy_by_Sector__Agriculture(
         res = res.add(eff_loss, fill_value=0)
 
     return res
+
+
+def Final_Energy_by_Sector__Residential_and_Commercial(
+    n: pypsa.Network,
+    aggregate_per_year: bool = True,
+) -> pd.Series | pd.DataFrame:
+    """Extract residential and commercial-sector final energy from a PyPSA Network.
+
+    Returns the total energy consumed by the transportation sector (excluding
+    transmission / distribution losses) across the pypsa-network.
+
+    Parameters
+    ----------
+    n : pypsa.Network
+        PyPSA network to process.
+    aggregate_per_year : bool, optional
+        If ``True`` (default), aggregate over all snapshots and return a
+        :class:`pandas.Series`.  If ``False``, return a
+        :class:`pandas.DataFrame` with snapshots as columns.
+
+    Returns
+    -------
+    pd.Series | pd.DataFrame
+        Pandas Series (``aggregate_per_year=True``) or DataFrame
+        (``aggregate_per_year=False``) with MultiIndex of ``location`` and
+        ``unit``.
+        Returns data at regional level as provided by the PyPSA network.
+        Country-level aggregation is handled by
+        Network_Processor._aggregate_to_country() if configured.
+
+    Notes
+    -----
+
+    """
+    # Final Energy|Residential and Commercial|Electricity
+    # include home batteries
+    # include decentral heating technologies
+    # exclude central heating technologies
+    # exclude EV charging.
+    low_voltage_elec = n.statistics.withdrawal(
+        bus_carrier="low voltage",
+        carrier=[
+            "rural resistive heater",
+            "urban decentral resistive heater",
+            "home battery discharger",
+            "home battery charger",
+            "rural air heat pump",
+            "rural ground heat pump",
+            "urban decentral air heat pump",
+        ],
+        groupby_time=aggregate_per_year,
+        **kwargs,
+    )
+
+    # Final Energy|Residential and Commercial|Heat
+    # urban central heat as bus_carrier
+    # decentral solar thermal
+    # exclude urban central heat vent
+    # exclude low-temperature-teat for industry
+    # exclude decentral heating systems
+    urban_central_heat = n.statistics.withdrawal(
+        bus_carrier="urban central heat",
+        carrier=[
+            "urban central water pits charger",
+            "urban central water tanks charger",
+            "DAC",
+            "urban central heat",
+        ],
+        groupby_time=aggregate_per_year,
+        **kwargs,
+    )
+
+    # Final Energy|Residential and Commercial|Gases
+    # urban decentral gas boiler, rural gas boiler
+    rescom_gas = n.statistics.energy_balance(
+        carrier=["urban decentral gas boiler", "rural gas boiler"],
+        components="Link",
+        at_port="bus0",  # count gas not heat
+        groupby_time=aggregate_per_year,
+        **kwargs,
+    ).mul(
+        -1
+    )  # positive Load
+
+    # Final Energy|Residential and Commercial|Liquids -> needs regionalization
+    raw_rescom = n.statistics.withdrawal(
+        bus_carrier="oil",
+        carrier=["rural oil boiler", "urban decentral oil boiler"],
+        groupby=kwargs_filtering["groupby"] + ["bus1"],
+        aggregate_time=aggregate_per_year,
+    )
+    if raw_rescom.empty:
+        rescom_liquids = raw_rescom
+    else:
+        raw_rescom = raw_rescom.drop("Store", errors="ignore")
+        usage_location = [
+            bus.split(" ")[0] for bus in list(raw_rescom.index.get_level_values("bus1"))
+        ]
+        rescom_liquids = (
+            create_location_index_from_copperplate(raw_rescom, usage_location)
+            .groupby(kwargs["groupby"])
+            .sum()
+        )
+
+    # Final Energy|Residential and Commercial|Solids (Biomass)
+    solids_usage = n.statistics.energy_balance(
+        bus_carrier="solid biomass",
+        carrier=["rural biomass boiler", "urban decentral biomass boiler"],
+        components="Link",
+        at_port="bus0",  # account for biomass not for heat
+        groupby_time=aggregate_per_year,
+        **kwargs,
+    ).mul(
+        -1
+    )  # positive Load
+
+    series_list = [
+        low_voltage_elec,
+        urban_central_heat,
+        rescom_gas,
+        rescom_liquids,
+        solids_usage,
+    ]
+    series_list = [
+        df.groupby(kwargs["groupby"]).sum() for df in series_list if not df.empty
+    ]
+    total = pd.concat(series_list)
+    return total

--- a/pypsa_validation_processing/statistics_functions.py
+++ b/pypsa_validation_processing/statistics_functions.py
@@ -434,11 +434,11 @@ def Final_Energy_by_Carrier__Natural_Gas(
     non_fossil_fraction = non_fossil_fraction.rename(index=UNITS_MAPPING)
 
     # Final Energy|Residential and Commercial|Natural Gas - urban decentral gas boiler
-    rescom = n.statistics.withdrawal(
-        bus_carrier="gas",
+    rescom_gas = n.statistics.energy_balance(
         carrier=["urban decentral gas boiler", "rural gas boiler"],
         components="Link",
-        aggregate_time=aggregate_per_year,
+        at_port="bus0",  # count gas not heat
+        groupby_time=aggregate_per_year,
         **kwargs,
     )
 
@@ -461,7 +461,7 @@ def Final_Energy_by_Carrier__Natural_Gas(
     energy_fraction_industry_gas = fc_energy / (fc_energy + fc_noenergy)
     industry = industry.mul(energy_fraction_industry_gas)
 
-    series_list = [rescom, industry]
+    series_list = [rescom_gas, industry]
     series_list = [series for series in series_list if not series.empty]
 
     if not series_list:

--- a/pypsa_validation_processing/statistics_functions.py
+++ b/pypsa_validation_processing/statistics_functions.py
@@ -854,12 +854,15 @@ def Final_Energy_by_Sector__Residential_and_Commercial(
     )  # positive Load
 
     # Final Energy|Residential and Commercial|Liquids -> needs regionalization
-    raw_rescom = n.statistics.withdrawal(
+    raw_rescom = n.statistics.energy_balance(
         bus_carrier="oil",
         carrier=["rural oil boiler", "urban decentral oil boiler"],
         groupby=kwargs_filtering["groupby"] + ["bus1"],
+        at_port="bus0",  # count oil not heat
         groupby_time=aggregate_per_year,
-    )
+    ).mul(
+        -1
+    )  # positive Load
     if raw_rescom.empty:
         rescom_liquids = raw_rescom
     else:

--- a/pypsa_validation_processing/statistics_functions.py
+++ b/pypsa_validation_processing/statistics_functions.py
@@ -775,8 +775,8 @@ def Final_Energy_by_Sector__Residential_and_Commercial(
 ) -> pd.Series | pd.DataFrame:
     """Extract residential and commercial-sector final energy from a PyPSA Network.
 
-    Returns the total energy consumed by the transportation sector (excluding
-    transmission / distribution losses) across the pypsa-network.
+    Returns the total energy consumed by the sector residentials and
+    commercials across the pypsa-network.
 
     Parameters
     ----------
@@ -799,7 +799,9 @@ def Final_Energy_by_Sector__Residential_and_Commercial(
 
     Notes
     -----
-
+    excludes EV-charging, as covered by Sector Transportation. Concerning Carrier heat, the Function distinguishes between
+    central heating systems (Final Energy is Heat) and decentral heating systems (Final Energy is Electricity, Gas, Liquids
+    or Solids).
     """
     # Final Energy|Residential and Commercial|Electricity
     # include home batteries

--- a/pypsa_validation_processing/statistics_functions.py
+++ b/pypsa_validation_processing/statistics_functions.py
@@ -81,13 +81,13 @@ def Final_Energy_by_Carrier__Electricity(
     agri = n.statistics.withdrawal(
         carrier=["agriculture electricity", "agriculture machinery electric"],
         components="Load",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs,
     )
 
     # get Final Energy|Residential and Commercial|Electricity
     lv = n.statistics.withdrawal(
-        bus_carrier="low voltage", aggregate_time=aggregate_per_year, **kwargs_filtering
+        bus_carrier="low voltage", groupby_time=aggregate_per_year, **kwargs_filtering
     )
     forbidden_parts = [
         "urban central",
@@ -106,7 +106,7 @@ def Final_Energy_by_Carrier__Electricity(
         bus_carrier="low voltage",
         carrier="BEV charger",
         components="Link",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs,
     )
 
@@ -114,7 +114,7 @@ def Final_Energy_by_Carrier__Electricity(
     industry = n.statistics.withdrawal(
         carrier="industry electricity",
         components="Load",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs,
     )
 
@@ -123,7 +123,7 @@ def Final_Energy_by_Carrier__Electricity(
         bus_carrier="AC",
         carrier="DAC",
         components="Link",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs,
     )
 
@@ -171,7 +171,7 @@ def Final_Energy_by_Carrier__Coal(
         bus_carrier="coal for industry",
         carrier="coal for industry",
         components="Load",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs,
     )
     return industry
@@ -238,7 +238,7 @@ def Final_Energy_by_Carrier__Oil(
     agri = n.statistics.withdrawal(
         carrier="agriculture machinery oil",
         components="Load",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs,
     )
 
@@ -247,7 +247,7 @@ def Final_Energy_by_Carrier__Oil(
         bus_carrier="oil",
         carrier=["rural oil boiler", "urban decentral oil boiler"],
         groupby=kwargs_filtering["groupby"] + ["bus1"],
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
     )
     if raw_rescom.empty:
         rescom = raw_rescom
@@ -266,7 +266,7 @@ def Final_Energy_by_Carrier__Oil(
     transpo = n.statistics.withdrawal(
         carrier="land transport oil",
         components="Load",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs,
     )
 
@@ -404,7 +404,7 @@ def Final_Energy_by_Carrier__Natural_Gas(
         ],
         at_port="bus1",
         components="Link",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs,
     )
 
@@ -412,7 +412,7 @@ def Final_Energy_by_Carrier__Natural_Gas(
     all_gas = n.statistics.withdrawal(
         bus_carrier="gas",
         components="Link",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs_filtering,
     )
     all_gas.index.get_level_values("carrier").unique()
@@ -447,7 +447,7 @@ def Final_Energy_by_Carrier__Natural_Gas(
         bus_carrier="gas for industry",
         carrier=["gas for industry", "gas for industry CC"],
         components="Load",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs,
     )
 
@@ -553,7 +553,7 @@ def Final_Energy_by_Sector__Transportation(
         bus_carrier="low voltage",
         carrier="BEV charger",
         components="Link",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs,
     ).mul(
         1 / eff
@@ -563,7 +563,7 @@ def Final_Energy_by_Sector__Transportation(
     h2 = n.statistics.withdrawal(
         carrier="land transport fuel cell",
         components="Load",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs,
     )
 
@@ -572,7 +572,7 @@ def Final_Energy_by_Sector__Transportation(
         n.statistics.withdrawal(
             carrier="kerosene for aviation",
             components="Load",
-            aggregate_time=aggregate_per_year,
+            groupby_time=aggregate_per_year,
             **kwargs,
         )
         * domestic_aviation_fraction
@@ -582,7 +582,7 @@ def Final_Energy_by_Sector__Transportation(
         n.statistics.withdrawal(
             carrier=["shipping oil", "shipping methanol"],
             components="Load",
-            aggregate_time=aggregate_per_year,
+            groupby_time=aggregate_per_year,
             **kwargs,
         )
         * domestic_navigation_fraction
@@ -591,7 +591,7 @@ def Final_Energy_by_Sector__Transportation(
     land_transport_liquids = n.statistics.withdrawal(
         carrier="land transport oil",
         components="Load",
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
         **kwargs,
     )
 
@@ -856,7 +856,7 @@ def Final_Energy_by_Sector__Residential_and_Commercial(
         bus_carrier="oil",
         carrier=["rural oil boiler", "urban decentral oil boiler"],
         groupby=kwargs_filtering["groupby"] + ["bus1"],
-        aggregate_time=aggregate_per_year,
+        groupby_time=aggregate_per_year,
     )
     if raw_rescom.empty:
         rescom_liquids = raw_rescom

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,24 +127,19 @@ class MockStatisticsAccessor:
         bus_carrier: str | None = None,
         carrier: list[str] | str | None = None,
         components: str | list[str] | None = None,
-        aggregate_time: bool = True,
+        groupby_time: bool = True,
         groupby: list[str] | None = None,
         nice_names: bool | None = None,
         **kwargs: object,
     ) -> pd.Series | pd.DataFrame:
-        """Mock withdrawal method forwarding to energy_balance.
-
-        PyPSA's statistics.withdrawal uses ``aggregate_time`` while
-        ``energy_balance`` uses ``groupby_time``. This adapter keeps tests
-        compatible with either call style.
-        """
+        """Mock withdrawal method forwarding to energy_balance."""
         return self.energy_balance(
             bus_carrier=bus_carrier,
             carrier=carrier,
             components=components,
             groupby=groupby,
             direction="withdrawal",
-            groupby_time=aggregate_time,
+            groupby_time=groupby_time,
             nice_names=nice_names,
             **kwargs,
         )

--- a/tests/test_statistics_functions.py
+++ b/tests/test_statistics_functions.py
@@ -51,7 +51,7 @@ class TestFinalEnergyByCarrierElectricity:
             bus_carrier: str | None = None,
             carrier: list[str] | str | None = None,
             components: str | list[str] | None = None,
-            aggregate_time: bool = True,
+            groupby_time: bool = False,
             groupby: list[str] | None = None,
             nice_names: bool | None = None,
             **_: object,
@@ -61,7 +61,7 @@ class TestFinalEnergyByCarrierElectricity:
                     "bus_carrier": bus_carrier,
                     "carrier": carrier,
                     "components": components,
-                    "aggregate_time": aggregate_time,
+                    "groupby_time": groupby_time,
                     "groupby": groupby,
                     "nice_names": nice_names,
                 }
@@ -250,9 +250,9 @@ class TestFinalEnergyByCarrierOil:
             *,
             index: pd.MultiIndex,
             values: list[float],
-            aggregate_time: bool,
+            groupby_time: bool,
         ) -> pd.Series | pd.DataFrame:
-            if aggregate_time:
+            if groupby_time:
                 return pd.Series(values, index=index, dtype=float)
             timestamps = pd.date_range(
                 "2019-01-01", periods=4, freq="6h", name="snapshot"
@@ -266,7 +266,7 @@ class TestFinalEnergyByCarrierOil:
             bus_carrier: str | None = None,
             carrier: list[str] | str | None = None,
             components: str | list[str] | None = None,
-            aggregate_time: bool = True,
+            groupby_time: bool = True,
             groupby: list[str] | None = None,
             at_port: str | None = None,
             **kwargs: object,
@@ -280,7 +280,7 @@ class TestFinalEnergyByCarrierOil:
                     [("AT1", "MWh_th")], names=["location", "unit"]
                 )
                 return self._to_result(
-                    index=idx, values=[100.0], aggregate_time=aggregate_time
+                    index=idx, values=[100.0], groupby_time=groupby_time
                 )
 
             if carrier == "land transport oil" and components == "Load":
@@ -288,7 +288,7 @@ class TestFinalEnergyByCarrierOil:
                     [("AT1", "MWh_th")], names=["location", "unit"]
                 )
                 return self._to_result(
-                    index=idx, values=[300.0], aggregate_time=aggregate_time
+                    index=idx, values=[300.0], groupby_time=groupby_time
                 )
 
             # Residential/commercial demand requiring copperplate -> location mapping via bus1
@@ -305,7 +305,7 @@ class TestFinalEnergyByCarrierOil:
                     return self._to_result(
                         index=empty_idx,
                         values=[],
-                        aggregate_time=aggregate_time,
+                        groupby_time=groupby_time,
                     )
                 idx = pd.MultiIndex.from_tuples(
                     [
@@ -331,7 +331,7 @@ class TestFinalEnergyByCarrierOil:
                 return self._to_result(
                     index=idx,
                     values=[50.0, 50.0],
-                    aggregate_time=aggregate_time,
+                    groupby_time=groupby_time,
                 )
 
             # Total oil use denominator for non-fossil share
@@ -349,7 +349,7 @@ class TestFinalEnergyByCarrierOil:
                     return self._to_result(
                         index=empty_idx,
                         values=[],
-                        aggregate_time=aggregate_time,
+                        groupby_time=groupby_time,
                     )
                 idx = pd.MultiIndex.from_tuples(
                     [
@@ -365,7 +365,7 @@ class TestFinalEnergyByCarrierOil:
                 return self._to_result(
                     index=idx,
                     values=[self.all_oil_value],
-                    aggregate_time=aggregate_time,
+                    groupby_time=groupby_time,
                 )
 
             raise AssertionError(
@@ -379,7 +379,7 @@ class TestFinalEnergyByCarrierOil:
             at_port: str | None = None,
             components: str | list[str] | None = None,
             groupby: list[str] | None = None,
-            aggregate_time: bool = True,
+            groupby_time: bool = True,
             **kwargs: object,
         ) -> pd.Series | pd.DataFrame:
             if (
@@ -396,7 +396,7 @@ class TestFinalEnergyByCarrierOil:
                     return self._to_result(
                         index=empty_idx,
                         values=[],
-                        aggregate_time=aggregate_time,
+                        groupby_time=groupby_time,
                     )
                 idx = pd.MultiIndex.from_tuples(
                     [
@@ -412,7 +412,7 @@ class TestFinalEnergyByCarrierOil:
                     names=["name", "bus", "carrier", "location", "unit", "bus0"],
                 )
                 return self._to_result(
-                    index=idx, values=[500.0], aggregate_time=aggregate_time
+                    index=idx, values=[500.0], groupby_time=groupby_time
                 )
 
             raise AssertionError(
@@ -555,7 +555,7 @@ class TestFinalEnergyByCarrierNaturalGas:
             carrier: list[str] | str | None = None,
             at_port: str | None = None,
             components: str | list[str] | None = None,
-            aggregate_time: bool = True,
+            groupby_time: bool = True,
             groupby: list[str] | None = None,
             nice_names: bool | None = None,
             **_: object,
@@ -572,10 +572,10 @@ class TestFinalEnergyByCarrierNaturalGas:
                 if self.scenario in ("no_gas", "no_renewable"):
                     return self._empty_series(groupby)
                 if self.scenario == "no_fossil":
-                    if aggregate_time:
+                    if groupby_time:
                         return self._series_from_groupby(groupby, [100.0])
                     return self._dataframe_from_groupby(groupby, [100.0, 100.0])
-                if aggregate_time:
+                if groupby_time:
                     return self._series_from_groupby(groupby, [20.0])
                 return self._dataframe_from_groupby(groupby, [20.0, 20.0])
 
@@ -586,7 +586,7 @@ class TestFinalEnergyByCarrierNaturalGas:
             bus_carrier: str | None = None,
             carrier: list[str] | str | None = None,
             components: str | list[str] | None = None,
-            aggregate_time: bool = True,
+            groupby_time: bool = True,
             groupby: list[str] | None = None,
             nice_names: bool | None = None,
             **_: object,
@@ -621,7 +621,7 @@ class TestFinalEnergyByCarrierNaturalGas:
                     ],
                     names=groupby,
                 )
-                if aggregate_time:
+                if groupby_time:
                     return pd.Series([100.0, 900.0], index=index, dtype=float)
                 columns = pd.Index(
                     pd.to_datetime(["2019-01-01", "2019-01-02"]), name="snapshot"
@@ -637,7 +637,7 @@ class TestFinalEnergyByCarrierNaturalGas:
             ):
                 if self.scenario == "no_gas":
                     return self._empty_series(groupby)
-                if aggregate_time:
+                if groupby_time:
                     return self._series_from_groupby(groupby, [40.0])
                 return self._dataframe_from_groupby(groupby, [40.0, 40.0])
 
@@ -648,7 +648,7 @@ class TestFinalEnergyByCarrierNaturalGas:
             ):
                 if self.scenario == "no_gas":
                     return self._empty_series(groupby)
-                if aggregate_time:
+                if groupby_time:
                     return self._series_from_groupby(groupby, [60.0])
                 return self._dataframe_from_groupby(groupby, [60.0, 60.0])
 
@@ -747,9 +747,9 @@ class TestFinalEnergyByCarrierOil:
             *,
             index: pd.MultiIndex,
             values: list[float],
-            aggregate_time: bool,
+            groupby_time: bool,
         ) -> pd.Series | pd.DataFrame:
-            if aggregate_time:
+            if groupby_time:
                 return pd.Series(values, index=index, dtype=float)
             timestamps = pd.date_range(
                 "2019-01-01", periods=4, freq="6h", name="snapshot"
@@ -763,7 +763,7 @@ class TestFinalEnergyByCarrierOil:
             bus_carrier: str | None = None,
             carrier: list[str] | str | None = None,
             components: str | list[str] | None = None,
-            aggregate_time: bool = True,
+            groupby_time: bool = True,
             groupby: list[str] | None = None,
             at_port: str | None = None,
             **kwargs: object,
@@ -777,7 +777,7 @@ class TestFinalEnergyByCarrierOil:
                     [("AT1", "MWh_th")], names=["location", "unit"]
                 )
                 return self._to_result(
-                    index=idx, values=[100.0], aggregate_time=aggregate_time
+                    index=idx, values=[100.0], groupby_time=groupby_time
                 )
 
             if carrier == "land transport oil" and components == "Load":
@@ -785,7 +785,7 @@ class TestFinalEnergyByCarrierOil:
                     [("AT1", "MWh_th")], names=["location", "unit"]
                 )
                 return self._to_result(
-                    index=idx, values=[300.0], aggregate_time=aggregate_time
+                    index=idx, values=[300.0], groupby_time=groupby_time
                 )
 
             # Residential/commercial demand requiring copperplate -> location mapping via bus1
@@ -802,7 +802,7 @@ class TestFinalEnergyByCarrierOil:
                     return self._to_result(
                         index=empty_idx,
                         values=[],
-                        aggregate_time=aggregate_time,
+                        groupby_time=groupby_time,
                     )
                 idx = pd.MultiIndex.from_tuples(
                     [
@@ -828,7 +828,7 @@ class TestFinalEnergyByCarrierOil:
                 return self._to_result(
                     index=idx,
                     values=[50.0, 50.0],
-                    aggregate_time=aggregate_time,
+                    groupby_time=groupby_time,
                 )
 
             # Total oil use denominator for non-fossil share
@@ -846,7 +846,7 @@ class TestFinalEnergyByCarrierOil:
                     return self._to_result(
                         index=empty_idx,
                         values=[],
-                        aggregate_time=aggregate_time,
+                        groupby_time=groupby_time,
                     )
                 idx = pd.MultiIndex.from_tuples(
                     [
@@ -862,7 +862,7 @@ class TestFinalEnergyByCarrierOil:
                 return self._to_result(
                     index=idx,
                     values=[self.all_oil_value],
-                    aggregate_time=aggregate_time,
+                    groupby_time=groupby_time,
                 )
 
             raise AssertionError(
@@ -876,7 +876,7 @@ class TestFinalEnergyByCarrierOil:
             at_port: str | None = None,
             components: str | list[str] | None = None,
             groupby: list[str] | None = None,
-            aggregate_time: bool = True,
+            groupby_time: bool = True,
             **kwargs: object,
         ) -> pd.Series | pd.DataFrame:
             if (
@@ -893,7 +893,7 @@ class TestFinalEnergyByCarrierOil:
                     return self._to_result(
                         index=empty_idx,
                         values=[],
-                        aggregate_time=aggregate_time,
+                        groupby_time=groupby_time,
                     )
                 idx = pd.MultiIndex.from_tuples(
                     [
@@ -909,7 +909,7 @@ class TestFinalEnergyByCarrierOil:
                     names=["name", "bus", "carrier", "location", "unit", "bus0"],
                 )
                 return self._to_result(
-                    index=idx, values=[500.0], aggregate_time=aggregate_time
+                    index=idx, values=[500.0], groupby_time=groupby_time
                 )
 
             raise AssertionError(
@@ -1029,7 +1029,7 @@ class TestFinalEnergyByCarrierCoal:
             bus_carrier: str | None = None,
             carrier: list[str] | str | None = None,
             components: str | list[str] | None = None,
-            aggregate_time: bool = True,
+            groupby_time: bool = True,
             groupby: list[str] | None = None,
             nice_names: bool | None = None,
             **_: object,
@@ -1039,7 +1039,7 @@ class TestFinalEnergyByCarrierCoal:
                     "bus_carrier": bus_carrier,
                     "carrier": carrier,
                     "components": components,
-                    "aggregate_time": aggregate_time,
+                    "groupby_time": groupby_time,
                     "groupby": groupby,
                     "nice_names": nice_names,
                 }
@@ -1365,7 +1365,7 @@ class TestFinalEnergyBySectorResidentialAndCommercial:
             bus_carrier: str | None = None,
             carrier: list[str] | str | None = None,
             components: str | list[str] | None = None,
-            aggregate_time: bool = True,
+            groupby_time: bool = True,
             groupby: list[str] | None = None,
             **kwargs: object,
         ) -> pd.Series | pd.DataFrame:
@@ -1376,7 +1376,7 @@ class TestFinalEnergyBySectorResidentialAndCommercial:
                 components=components,
                 groupby=groupby,
                 direction="withdrawal",
-                groupby_time=aggregate_time,
+                groupby_time=groupby_time,
                 **kwargs,
             )
 

--- a/tests/test_statistics_functions.py
+++ b/tests/test_statistics_functions.py
@@ -1490,7 +1490,7 @@ class TestFinalEnergyBySectorResidentialAndCommercial:
 
         grouped_result = result.groupby(level=["location", "unit"]).sum().sort_index()
         expected = pd.Series(
-            [11.0, 12.0, -22.0, -22.0],
+            [11.0, 12.0, -24.0, -26.0],
             index=pd.MultiIndex.from_tuples(
                 [
                     ("AT1", "MWh_el"),

--- a/tests/test_statistics_functions.py
+++ b/tests/test_statistics_functions.py
@@ -1366,11 +1366,16 @@ class TestFinalEnergyBySectorResidentialAndCommercial:
                 index_tuples.append(tuple(idx_dict.get(key, f"mock_{key}") for key in groupby))
 
             index = pd.MultiIndex.from_tuples(index_tuples, names=groupby)
+            timestamps = pd.date_range("2019-01-01", periods=4, freq="6h", name="snapshot")
             if groupby_time:
                 return pd.Series(values, index=index, dtype=float)
 
-            timestamps = pd.date_range("2019-01-01", periods=4, freq="6h", name="snapshot")
-            return pd.DataFrame({ts: values for ts in timestamps}, index=index, dtype=float)
+            per_snapshot_values = [value / len(timestamps) for value in values]
+            return pd.DataFrame(
+                {ts: per_snapshot_values for ts in timestamps},
+                index=index,
+                dtype=float,
+            )
 
         def energy_balance(
             self,
@@ -1379,8 +1384,9 @@ class TestFinalEnergyBySectorResidentialAndCommercial:
             components: str | list[str] | None = None,
             groupby: list[str] | None = None,
             direction: str = "withdrawal",
-            at_port: list[str] | None = None,
+            at_port: str | list[str] | None = None,
             groupby_time: bool = True,
+            nice_names: bool | None = None,
             **_: object,
         ) -> pd.Series | pd.DataFrame:
             self.calls.append(
@@ -1392,11 +1398,15 @@ class TestFinalEnergyBySectorResidentialAndCommercial:
                     "direction": direction,
                     "at_port": at_port,
                     "groupby_time": groupby_time,
+                    "nice_names": nice_names,
                 }
             )
 
             if groupby is None:
                 groupby = ["location", "unit"]
+
+            if components == "Link" and at_port not in ("bus0", ["bus0"]):
+                return self._series_or_frame(groupby, [], [], "MWh_th", groupby_time)
 
             if carrier == ["rural biomass boiler", "urban decentral biomass boiler"]:
                 return self._series_or_frame(groupby, ["AT1", "AT2"], [21.0, 22.0], "MWh_th", groupby_time)
@@ -1450,6 +1460,51 @@ class TestFinalEnergyBySectorResidentialAndCommercial:
         )
         assert isinstance(result, pd.Series)
 
+    def test_uses_bus0_for_gas_and_biomass(self):
+        """Test that gas and biomass are queried on bus0."""
+        network = self._residential_and_commercial_network()
+
+        _ = Final_Energy_by_Sector__Residential_and_Commercial(network)
+
+        gas_calls = [
+            call
+            for call in network.statistics.calls
+            if call["carrier"] == ["urban decentral gas boiler", "rural gas boiler"]
+        ]
+        biomass_calls = [
+            call
+            for call in network.statistics.calls
+            if call["bus_carrier"] == "solid biomass"
+        ]
+
+        assert gas_calls
+        assert biomass_calls
+        assert all(call["at_port"] == "bus0" for call in gas_calls)
+        assert all(call["at_port"] == "bus0" for call in biomass_calls)
+
+    def test_aggregates_all_fuel_types_per_location(self):
+        """Test that all fuel types are combined correctly per location."""
+        result = Final_Energy_by_Sector__Residential_and_Commercial(
+            self._residential_and_commercial_network()
+        )
+
+        grouped_result = result.groupby(level=["location", "unit"]).sum().sort_index()
+        expected = pd.Series(
+            [11.0, 12.0, -22.0, -22.0],
+            index=pd.MultiIndex.from_tuples(
+                [
+                    ("AT1", "MWh_el"),
+                    ("AT2", "MWh_el"),
+                    ("AT1", "MWh_th"),
+                    ("AT2", "MWh_th"),
+                ],
+                names=["location", "unit"],
+            ),
+            dtype=float,
+        ).sort_index()
+
+        pd.testing.assert_series_equal(grouped_result, expected)
+
     def test_has_location_and_unit_multiindex(self):
         """Test that result has MultiIndex with location and unit levels."""
         result = Final_Energy_by_Sector__Residential_and_Commercial(
@@ -1496,14 +1551,18 @@ class TestFinalEnergyBySectorResidentialAndCommercial:
 
     def test_returns_dataframe_when_not_aggregated(self):
         """aggregate_per_year=False returns a DataFrame with snapshot columns."""
+        network = self._residential_and_commercial_network()
         result = Final_Energy_by_Sector__Residential_and_Commercial(
-            self._residential_and_commercial_network(), aggregate_per_year=False
+            network, aggregate_per_year=False
         )
+        aggregated_result = Final_Energy_by_Sector__Residential_and_Commercial(network)
         assert isinstance(result, pd.DataFrame)
         assert isinstance(result.index, pd.MultiIndex)
         assert result.index.names == ["location", "unit"]
         assert any(isinstance(column, pd.Timestamp) for column in result.columns)
+        assert len(result.columns) == 4
         assert not result.empty
+        pd.testing.assert_series_equal(result.sum(axis=1), aggregated_result)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_statistics_functions.py
+++ b/tests/test_statistics_functions.py
@@ -12,6 +12,7 @@ from pypsa_validation_processing.statistics_functions import (
     Final_Energy_by_Carrier__Oil,
     Final_Energy_by_Sector__Industry,
     Final_Energy_by_Sector__Agriculture,
+    Final_Energy_by_Sector__Residential_and_Commercial,
     Final_Energy_by_Sector__Transportation,
 )
 
@@ -1276,6 +1277,181 @@ class TestFinalEnergyBySectorAgriculture:
         assert result.index.names == ["location", "unit"]
         # Result should still have valid data
         assert len(result) > 0
+
+
+# ---------------------------------------------------------------------------
+# Tests for Final_Energy_by_Sector__Residential_and_Commercial
+# ---------------------------------------------------------------------------
+
+
+class TestFinalEnergyBySectorResidentialAndCommercial:
+    """Test suite for Final_Energy_by_Sector__Residential_and_Commercial function."""
+
+    class _ResidentialAndCommercialStatisticsAccessor:
+        """Minimal accessor for residential and commercial sector tests."""
+
+        def __init__(self):
+            self.calls: list[dict] = []
+
+        @staticmethod
+        def _series_or_frame(
+            groupby: list[str],
+            locations: list[str],
+            values: list[float],
+            unit: str,
+            groupby_time: bool,
+        ) -> pd.Series | pd.DataFrame:
+            index_tuples = []
+            for location in locations:
+                idx_dict = {
+                    "name": f"{location} demand",
+                    "carrier": "mock carrier",
+                    "bus1": f"{location} bus",
+                    "bus0": f"{location} bus",
+                    "location": location,
+                    "unit": unit,
+                }
+                index_tuples.append(tuple(idx_dict.get(key, f"mock_{key}") for key in groupby))
+
+            index = pd.MultiIndex.from_tuples(index_tuples, names=groupby)
+            if groupby_time:
+                return pd.Series(values, index=index, dtype=float)
+
+            timestamps = pd.date_range("2019-01-01", periods=4, freq="6h", name="snapshot")
+            return pd.DataFrame({ts: values for ts in timestamps}, index=index, dtype=float)
+
+        def energy_balance(
+            self,
+            bus_carrier: str | None = None,
+            carrier: list[str] | str | None = None,
+            components: str | list[str] | None = None,
+            groupby: list[str] | None = None,
+            direction: str = "withdrawal",
+            at_port: list[str] | None = None,
+            groupby_time: bool = True,
+            **_: object,
+        ) -> pd.Series | pd.DataFrame:
+            self.calls.append(
+                {
+                    "bus_carrier": bus_carrier,
+                    "carrier": carrier,
+                    "components": components,
+                    "groupby": groupby,
+                    "direction": direction,
+                    "at_port": at_port,
+                    "groupby_time": groupby_time,
+                }
+            )
+
+            if groupby is None:
+                groupby = ["location", "unit"]
+
+            if carrier == ["rural biomass boiler", "urban decentral biomass boiler"]:
+                return self._series_or_frame(groupby, ["AT1", "AT2"], [21.0, 22.0], "MWh_th", groupby_time)
+
+            if bus_carrier == "low voltage":
+                return self._series_or_frame(groupby, ["AT1", "AT2"], [11.0, 12.0], "MWh_el", groupby_time)
+
+            if bus_carrier == "urban central heat":
+                return self._series_or_frame(groupby, ["AT1", "AT2"], [13.0, 14.0], "MWh_th", groupby_time)
+
+            if carrier == ["urban decentral gas boiler", "rural gas boiler"]:
+                return self._series_or_frame(groupby, ["AT1", "AT2"], [15.0, 16.0], "MWh_th", groupby_time)
+
+            return self._series_or_frame(groupby, ["AT1", "AT2"], [1.0, 2.0], "MWh_th", groupby_time)
+
+        def withdrawal(
+            self,
+            bus_carrier: str | None = None,
+            carrier: list[str] | str | None = None,
+            components: str | list[str] | None = None,
+            aggregate_time: bool = True,
+            groupby: list[str] | None = None,
+            **kwargs: object,
+        ) -> pd.Series | pd.DataFrame:
+            kwargs.pop("groupby_time", None)
+            return self.energy_balance(
+                bus_carrier=bus_carrier,
+                carrier=carrier,
+                components=components,
+                groupby=groupby,
+                direction="withdrawal",
+                groupby_time=aggregate_time,
+                **kwargs,
+            )
+
+    class _ResidentialAndCommercialNetwork:
+        """Minimal network object exposing a residential/commercial statistics accessor."""
+
+        def __init__(self):
+            self.statistics = (
+                TestFinalEnergyBySectorResidentialAndCommercial._ResidentialAndCommercialStatisticsAccessor()
+            )
+
+    def _residential_and_commercial_network(self):
+        return self._ResidentialAndCommercialNetwork()
+
+    def test_returns_series(self):
+        """Test that the function returns a pandas Series."""
+        result = Final_Energy_by_Sector__Residential_and_Commercial(
+            self._residential_and_commercial_network()
+        )
+        assert isinstance(result, pd.Series)
+
+    def test_has_location_and_unit_multiindex(self):
+        """Test that result has MultiIndex with location and unit levels."""
+        result = Final_Energy_by_Sector__Residential_and_Commercial(
+            self._residential_and_commercial_network()
+        )
+        assert isinstance(result.index, pd.MultiIndex)
+        assert result.index.names == ["location", "unit"]
+
+    def test_not_empty(self):
+        """Test that result is not empty."""
+        result = Final_Energy_by_Sector__Residential_and_Commercial(
+            self._residential_and_commercial_network()
+        )
+        assert len(result) > 0
+
+    def test_numeric_values(self):
+        """Test that result values are numeric."""
+        result = Final_Energy_by_Sector__Residential_and_Commercial(
+            self._residential_and_commercial_network()
+        )
+        assert result.dtype in [float, int] or pd.api.types.is_numeric_dtype(
+            result.dtype
+        )
+
+    def test_contains_multiple_locations(self):
+        """Test that result contains multiple locational data."""
+        result = Final_Energy_by_Sector__Residential_and_Commercial(
+            self._residential_and_commercial_network()
+        )
+        locations = result.index.get_level_values("location").unique()
+        assert len(locations) > 1
+        assert all(r.startswith("AT") for r in locations)
+
+    def test_multiple_networks(self, mock_network_collection: MockNetworkCollection):
+        """Test processing multiple networks from collection."""
+        for _ in mock_network_collection:
+            result = Final_Energy_by_Sector__Residential_and_Commercial(
+                self._residential_and_commercial_network()
+            )
+            assert isinstance(result, pd.Series)
+            assert isinstance(result.index, pd.MultiIndex)
+            assert result.index.names == ["location", "unit"]
+            assert len(result) > 0
+
+    def test_returns_dataframe_when_not_aggregated(self):
+        """aggregate_per_year=False returns a DataFrame with snapshot columns."""
+        result = Final_Energy_by_Sector__Residential_and_Commercial(
+            self._residential_and_commercial_network(), aggregate_per_year=False
+        )
+        assert isinstance(result, pd.DataFrame)
+        assert isinstance(result.index, pd.MultiIndex)
+        assert result.index.names == ["location", "unit"]
+        assert any(isinstance(column, pd.Timestamp) for column in result.columns)
+        assert not result.empty
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_statistics_functions.py
+++ b/tests/test_statistics_functions.py
@@ -512,6 +512,7 @@ class TestFinalEnergyByCarrierNaturalGas:
 
         def __init__(self, scenario: str = "mixed"):
             self.scenario = scenario
+            self.calls: list[dict[str, object]] = []
 
         @staticmethod
         def _empty_series(groupby: list[str]) -> pd.Series:
@@ -578,6 +579,45 @@ class TestFinalEnergyByCarrierNaturalGas:
                 if groupby_time:
                     return self._series_from_groupby(groupby, [20.0])
                 return self._dataframe_from_groupby(groupby, [20.0, 20.0])
+
+            return self._empty_series(groupby)
+
+        def energy_balance(
+            self,
+            bus_carrier: str | None = None,
+            carrier: list[str] | str | None = None,
+            components: str | list[str] | None = None,
+            at_port: str | list[str] | None = None,
+            # groupby_time: bool = True,
+            groupby: list[str] | None = None,
+            groupby_time: bool | None = None,
+            **_: object,
+        ) -> pd.Series | pd.DataFrame:
+            if groupby is None:
+                groupby = ["location", "unit"]
+
+            self.calls.append(
+                {
+                    "bus_carrier": bus_carrier,
+                    "carrier": carrier,
+                    "components": components,
+                    "at_port": at_port,
+                    "groupby_time": groupby_time,
+                    "groupby": groupby,
+                    "groupby_time": groupby_time,
+                }
+            )
+
+            if (
+                carrier == ["urban decentral gas boiler", "rural gas boiler"]
+                and components == "Link"
+                and at_port == "bus0"
+            ):
+                if self.scenario == "no_gas":
+                    return self._empty_series(groupby)
+                if groupby_time:
+                    return self._series_from_groupby(groupby, [40.0])
+                return self._dataframe_from_groupby(groupby, [40.0, 40.0])
 
             return self._empty_series(groupby)
 
@@ -692,6 +732,19 @@ class TestFinalEnergyByCarrierNaturalGas:
         )
         # total=100, non-fossil share=20/100, result=100*(1-0.2)=80
         assert result.loc[("AT1", "MWh")] == pytest.approx(77.1322, 0.1)
+
+    def test_uses_energy_balance_for_residential_and_commercial_gas(self):
+        """Residential/commercial gas demand is now taken from energy_balance."""
+        network = self._natural_gas_network("mixed")
+
+        _ = Final_Energy_by_Carrier__Natural_Gas(network)
+
+        assert any(
+            call["carrier"] == ["urban decentral gas boiler", "rural gas boiler"]
+            and call["components"] == "Link"
+            and call["at_port"] == "bus0"
+            for call in network.statistics.calls
+        )
 
     def test_edge_case_no_gas_returns_empty_series(self):
         """No gas usage and no gas demand should return an empty result."""

--- a/tests/test_statistics_functions.py
+++ b/tests/test_statistics_functions.py
@@ -588,9 +588,8 @@ class TestFinalEnergyByCarrierNaturalGas:
             carrier: list[str] | str | None = None,
             components: str | list[str] | None = None,
             at_port: str | list[str] | None = None,
-            # groupby_time: bool = True,
             groupby: list[str] | None = None,
-            groupby_time: bool | None = None,
+            groupby_time: bool = True,
             **_: object,
         ) -> pd.Series | pd.DataFrame:
             if groupby is None:


### PR DESCRIPTION
**Adds a new function to extract the statistics of variable Final Energy [by Sector]|Residential and Commercial**

| variable | PyPSA-output | IAMC Energy Balance | Difference % | 🟢 🟡 🟠 🔴 |
| -- | -- | -- | -- | -- |
| Final Energy [by Sector]\|Residential and Commercial | 3.38184e5 | 3.704e5 | -8.7% | 🟢 in range |

### Steps
- [x] Write your pypsa-statistics and add it as a separate function to [statistics_functions.py](https://github.com/maxnutz/pypsa_validation_processing/blob/main/pypsa_validation_processing/statistics_functions.py) (please note the [naming and structural conventions](https://github.com/maxnutz/pypsa_validation_processing/tree/main#variables-statistics---functions)!)
- [x] add a comprehensive docstring to your function 
- [x] add the mapping variable_name <> function_name to [mapping.default.yaml](https://github.com/maxnutz/pypsa_validation_processing/blob/main/pypsa_validation_processing/configs/config.default.yaml) (and your personal mapping-file)
- [x] Add a testing routine for your Function to `tests/` - stick to the [testing-README](https://github.com/maxnutz/pypsa_validation_processing/blob/main/tests/README.md)
- [x] make sure, that the newest version of main is merged into your feature Branch

## Summary by Sourcery

Add residential and commercial sector final energy statistics and align statistics API usage with PyPSA’s groupby_time/energy_balance interface.

New Features:
- Introduce Final_Energy_by_Sector__Residential_and_Commercial to compute residential and commercial final energy by carrier and region.

Bug Fixes:
- Use energy_balance at the gas port (bus0) for residential and commercial natural gas demand to correctly count gas rather than delivered heat.
- Align statistics calls with the groupby_time parameter to match the current PyPSA statistics API and avoid mis-aggregated time results.

Enhancements:
- Extend natural gas statistics to record and verify calls to energy_balance for residential and commercial gas demand.
- Simplify test statistics accessors and mocks by routing withdrawal through energy_balance and recording calls for inspection.

Tests:
- Add a dedicated test suite for Final_Energy_by_Sector__Residential_and_Commercial covering return types, index structure, multi-location output and time aggregation behaviour.
- Extend natural gas statistics tests to verify that residential and commercial gas demand is sourced via energy_balance.