### PR TITLE
63 new variable statistics final energy by carrierdistrict heat

### DIFF
--- a/pypsa_validation_processing/configs/mapping.default.yaml
+++ b/pypsa_validation_processing/configs/mapping.default.yaml
@@ -9,6 +9,7 @@ Final Energy [by Carrier]|Electricity: Final_Energy_by_Carrier__Electricity
 Final Energy [by Carrier]|Coal: Final_Energy_by_Carrier__Coal
 Final Energy [by Carrier]|Natural Gas: Final_Energy_by_Carrier__Natural_Gas
 Final Energy [by Carrier]|Oil: Final_Energy_by_Carrier__Oil
+Final Energy [by Carrier]|District Heat: Final_Energy_by_Carrier__District_Heat
 Final Energy [by Sector]|Transportation: Final_Energy_by_Sector__Transportation
 Final Energy [by Sector]|Industry: Final_Energy_by_Sector__Industry
 Final Energy [by Sector]|Agriculture: Final_Energy_by_Sector__Agriculture

--- a/pypsa_validation_processing/statistics_functions.py
+++ b/pypsa_validation_processing/statistics_functions.py
@@ -30,6 +30,7 @@ from pypsa_validation_processing.utils import (
     statistics_kwargs_for_filtering as kwargs_filtering,
     statistics_kwargs as kwargs,
     UNITS_MAPPING,
+    remap_unit_index,
 )
 from pypsa_validation_processing.utils import (
     get_energy_totals_domestic_share,
@@ -553,12 +554,14 @@ def Final_Energy_by_Carrier__District_Heat(
     )
     # units need to be mapped to MWh for correct summing of final values
     # this is currently not a clean solution -> TODO: #73
-    idx_frame_res = res.index.to_frame(index=False)
-    idx_frame_heat_vent = heat_vent.index.to_frame(index=False)
-    idx_frame_res["unit"] = idx_frame_res["unit"].map(UNITS_MAPPING)
-    idx_frame_heat_vent["unit"] = idx_frame_heat_vent["unit"].map(UNITS_MAPPING)
-    res.index = pd.MultiIndex.from_frame(idx_frame_res)
-    heat_vent.index = pd.MultiIndex.from_frame(idx_frame_heat_vent)
+    res = remap_unit_index(res)
+    heat_vent = remap_unit_index(heat_vent)
+    # idx_frame_res = res.index.to_frame(index=False)
+    # idx_frame_heat_vent = heat_vent.index.to_frame(index=False)
+    # idx_frame_res["unit"] = idx_frame_res["unit"].map(UNITS_MAPPING)
+    # idx_frame_heat_vent["unit"] = idx_frame_heat_vent["unit"].map(UNITS_MAPPING)
+    # res.index = pd.MultiIndex.from_frame(idx_frame_res)
+    # heat_vent.index = pd.MultiIndex.from_frame(idx_frame_heat_vent)
     result = (res.groupby(["location", "unit"]).sum()).add(heat_vent, fill_value=0)
 
     return result

--- a/pypsa_validation_processing/statistics_functions.py
+++ b/pypsa_validation_processing/statistics_functions.py
@@ -527,11 +527,13 @@ def Final_Energy_by_Carrier__District_Heat(
 
     # get all carriers of links to central_heat_buses
     pattern = r"charger|discharger"
-    central_heat_supply_links_without_chargers = [
-        x
-        for x in central_heat_supply_links.carrier.unique()
-        if not re.search(pattern, x, re.IGNORECASE)
-    ]
+    carrier_series = central_heat_supply_links["carrier"].dropna().astype("string")
+    is_charger_or_discharger = carrier_series.str.contains(
+        pattern, case=False, regex=True
+    )
+    central_heat_supply_links_without_chargers = carrier_series[
+        ~is_charger_or_discharger
+    ].unique()
 
     res = n.statistics.withdrawal(
         bus_carrier=list(supply_bus_carriers),

--- a/pypsa_validation_processing/statistics_functions.py
+++ b/pypsa_validation_processing/statistics_functions.py
@@ -541,7 +541,27 @@ def Final_Energy_by_Carrier__District_Heat(
         aggregate_time=aggregate_per_year,
         **kwargs,
     )
-    return res
+
+    # urban central heat vent is a generator on urban central heat bus,
+    # but not a component of Final Energy and needs to be substracted.
+    heat_vent = n.statistics.energy_balance(
+        bus_carrier="urban central heat",
+        carrier="urban central heat vent",
+        components="Generator",
+        aggregate_time=aggregate_per_year,
+        **kwargs,
+    )
+    # units need to be mapped to MWh for correct summing of final values
+    # this is currently not a clean solution -> TODO: #73
+    idx_frame_res = res.index.to_frame(index=False)
+    idx_frame_heat_vent = heat_vent.index.to_frame(index=False)
+    idx_frame_res["unit"] = idx_frame_res["unit"].map(UNITS_MAPPING)
+    idx_frame_heat_vent["unit"] = idx_frame_heat_vent["unit"].map(UNITS_MAPPING)
+    res.index = pd.MultiIndex.from_frame(idx_frame_res)
+    heat_vent.index = pd.MultiIndex.from_frame(idx_frame_heat_vent)
+    result = (res.groupby(["location", "unit"]).sum()).add(heat_vent, fill_value=0)
+
+    return result
 
 
 def Final_Energy_by_Sector__Transportation(

--- a/pypsa_validation_processing/statistics_functions.py
+++ b/pypsa_validation_processing/statistics_functions.py
@@ -481,7 +481,36 @@ def Final_Energy_by_Carrier__District_Heat(
     n: pypsa.Network,
     aggregate_per_year: bool = True,
 ) -> pd.Series | pd.DataFrame:
-    """Extract heat from district heating facilities from a PyPSA Network."""
+    """Extract Final Energy of District Heat from PyPSA Network.
+
+    Returns the total final energy demand, district heating facilities
+    have to provide district heating.
+    Parameters
+    ----------
+    n : pypsa.Network
+        PyPSA network to process.
+    aggregate_per_year : bool, optional
+        If ``True`` (default), aggregate over all snapshots and return a
+        :class:`pandas.Series`. If ``False``, return a
+        :class:`pandas.DataFrame` with snapshots as columns.
+
+    Returns
+    -------
+    pd.Series | pd.DataFrame
+        Pandas Series (``aggregate_per_year=True``) or DataFrame
+        (``aggregate_per_year=False``) with MultiIndex including
+        ``location`` and ``unit``.
+        Returns data at regional level as provided by the PyPSA network.
+        Country-level aggregation is handled by
+        Network_Processor._aggregate_to_country() if configured.
+
+    Notes
+    -----
+    The energy demand of district heating is calculated based on the
+    links from other carriers buses to the urban central heat buses.
+    This includes waste heat from eg. DAC. Taking the withdrawal from
+    the source bus of the link gives the energy in elem of the source carrier.
+    """
     # get all buses that are connected to central heat bus with links
     central_heat_buses = n.buses[n.buses.carrier == "urban central heat"].index
     central_heat_supply_links = n.links[

--- a/pypsa_validation_processing/statistics_functions.py
+++ b/pypsa_validation_processing/statistics_functions.py
@@ -477,6 +477,42 @@ def Final_Energy_by_Carrier__Natural_Gas(
     return result
 
 
+def Final_Energy_by_Carrier__District_Heat(
+    n: pypsa.Network,
+    aggregate_per_year: bool = True,
+) -> pd.Series | pd.DataFrame:
+    """Extract heat from district heating facilities from a PyPSA Network."""
+    # get all buses that are connected to central heat bus with links
+    central_heat_buses = n.buses[n.buses.carrier == "urban central heat"].index
+    central_heat_supply_links = n.links[
+        (
+            n.links.bus1.isin(central_heat_buses)
+            | n.links.bus2.isin(central_heat_buses)
+            | n.links.bus3.isin(central_heat_buses)
+        )
+    ]
+    central_heat_supply_buses = n.buses[
+        n.buses.index.isin(central_heat_supply_links.bus0.values)
+    ]
+    supply_bus_carriers = central_heat_supply_buses.carrier.unique()
+
+    # get all carriers of links to central_heat_buses
+    pattern = r"charger|discharger"
+    central_heat_supply_links_without_chargers = [
+        x
+        for x in central_heat_supply_links.carrier.unique()
+        if not re.search(pattern, x, re.IGNORECASE)
+    ]
+
+    res = n.statistics.withdrawal(
+        bus_carrier=list(supply_bus_carriers),
+        carrier=list(central_heat_supply_links_without_chargers),
+        aggregate_time=aggregate_per_year,
+        **kwargs,
+    )
+    return res
+
+
 def Final_Energy_by_Sector__Transportation(
     n: pypsa.Network,
     aggregate_per_year: bool = True,

--- a/pypsa_validation_processing/statistics_functions.py
+++ b/pypsa_validation_processing/statistics_functions.py
@@ -486,6 +486,7 @@ def Final_Energy_by_Carrier__District_Heat(
 
     Returns the total final energy demand, district heating facilities
     have to provide district heating.
+
     Parameters
     ----------
     n : pypsa.Network
@@ -514,6 +515,7 @@ def Final_Energy_by_Carrier__District_Heat(
     """
     # get all buses that are connected to central heat bus with links
     central_heat_buses = n.buses[n.buses.carrier == "urban central heat"].index
+    # get all carriers of links to central_heat_buses
     central_heat_supply_links = n.links[
         (
             n.links.bus1.isin(central_heat_buses)
@@ -526,7 +528,6 @@ def Final_Energy_by_Carrier__District_Heat(
     ]
     supply_bus_carriers = central_heat_supply_buses.carrier.unique()
 
-    # get all carriers of links to central_heat_buses
     pattern = r"charger|discharger"
     carrier_series = central_heat_supply_links["carrier"].dropna().astype("string")
     is_charger_or_discharger = carrier_series.str.contains(

--- a/pypsa_validation_processing/utils.py
+++ b/pypsa_validation_processing/utils.py
@@ -130,6 +130,19 @@ UNITS_MAPPING = {
     "MWh": "MWh",
 }
 
+
+def remap_unit_index(
+    series: pd.Series, unit_mapping: dict = UNITS_MAPPING
+) -> pd.Series:
+    """Remaps unit index to standard value for statistics with need for
+    direct comparison of input-output flows."""
+    idx = series.index.to_frame(index=False)
+    idx["unit"] = idx["unit"].replace(unit_mapping)
+    out = series.copy()
+    out.index = pd.MultiIndex.from_frame(idx, names=series.index.names)
+    return out
+
+
 ## standards for statistics-functions
 # standardize kwargs for pypsa-statistics statements
 statistics_kwargs = {

--- a/tests/test_statistics_functions.py
+++ b/tests/test_statistics_functions.py
@@ -814,6 +814,50 @@ class TestFinalEnergyByCarrierDistrictHeat:
             )
             return pd.DataFrame([values[: len(columns)]], index=index, columns=columns)
 
+        def energy_balance(
+            self,
+            bus_carrier: str | list[str] | None = None,
+            carrier: list[str] | str | None = None,
+            components: str | list[str] | None = None,
+            aggregate_time: bool = True,
+            groupby: list[str] | None = None,
+            nice_names: bool | None = None,
+            **_: object,
+        ) -> pd.Series | pd.DataFrame:
+            self.calls.append(
+                {
+                    "bus_carrier": bus_carrier,
+                    "carrier": carrier,
+                    "components": components,
+                    "aggregate_time": aggregate_time,
+                    "groupby": groupby,
+                    "nice_names": nice_names,
+                }
+            )
+
+            if groupby is None:
+                groupby = ["location", "unit"]
+
+            if (
+                bus_carrier == "urban central heat"
+                and carrier == "urban central heat vent"
+                and components == "Generator"
+            ):
+                if aggregate_time:
+                    return self._series_from_groupby(groupby, [5.0])
+                return self._dataframe_from_groupby(groupby, [5.0, 5.0])
+
+            if aggregate_time:
+                return pd.Series(
+                    dtype=float,
+                    index=pd.MultiIndex.from_tuples([], names=groupby),
+                )
+            return pd.DataFrame(
+                index=pd.MultiIndex.from_tuples([], names=groupby),
+                columns=pd.Index(pd.to_datetime([], name="snapshot")),
+                dtype=float,
+            )
+
         def withdrawal(
             self,
             bus_carrier: str | list[str] | None = None,
@@ -926,12 +970,15 @@ class TestFinalEnergyByCarrierDistrictHeat:
         _ = Final_Energy_by_Carrier__District_Heat(network)
 
         calls = network.statistics.calls
-        assert len(calls) == 1
+        assert len(calls) == 2
         queried_carriers = set(calls[0]["carrier"])
         assert queried_carriers == {
             "urban central resistive heater",
             "urban central gas boiler",
         }
+        assert calls[1]["bus_carrier"] == "urban central heat"
+        assert calls[1]["carrier"] == "urban central heat vent"
+        assert calls[1]["components"] == "Generator"
 
     def test_uses_supply_bus_carriers_from_bus0(self):
         """bus_carrier query uses carriers from bus0 of relevant central-heat links."""
@@ -941,6 +988,7 @@ class TestFinalEnergyByCarrierDistrictHeat:
         queried_bus_carriers = set(network.statistics.calls[0]["bus_carrier"])
         # Links via bus0 include AC, gas, biomass and hydrogen supply buses.
         assert queried_bus_carriers == {"AC", "gas", "biomass", "hydrogen"}
+        assert network.statistics.calls[1]["carrier"] == "urban central heat vent"
 
     def test_returns_dataframe_for_aggregate_per_year_false(self):
         """aggregate_per_year=False returns timeseries DataFrame output."""

--- a/tests/test_statistics_functions.py
+++ b/tests/test_statistics_functions.py
@@ -8,6 +8,7 @@ import pytest
 from pypsa_validation_processing.statistics_functions import (
     Final_Energy_by_Carrier__Electricity,
     Final_Energy_by_Carrier__Coal,
+    Final_Energy_by_Carrier__District_Heat,
     Final_Energy_by_Carrier__Natural_Gas,
     Final_Energy_by_Carrier__Oil,
     Final_Energy_by_Sector__Industry,
@@ -715,6 +716,185 @@ class TestFinalEnergyByCarrierNaturalGas:
             self._natural_gas_network("no_renewable")
         )
         assert result.loc[("AT1", "MWh")] == pytest.approx(96.41536, 0.1)
+
+
+# ---------------------------------------------------------------------------
+# Tests for Final_Energy_by_Carrier__District_Heat
+# ---------------------------------------------------------------------------
+
+
+class TestFinalEnergyByCarrierDistrictHeat:
+    """Test suite for Final_Energy_by_Carrier__District_Heat function."""
+
+    class _DistrictHeatStatisticsAccessor:
+        """Minimal accessor to verify district-heat extraction behavior."""
+
+        def __init__(self):
+            self.calls: list[dict] = []
+
+        @staticmethod
+        def _series_from_groupby(
+            groupby: list[str],
+            values: list[float],
+            location: str = "AT1",
+            unit: str = "MWh_th",
+        ) -> pd.Series:
+            index = pd.MultiIndex.from_tuples(
+                [tuple({"location": location, "unit": unit}[k] for k in groupby)],
+                names=groupby,
+            )
+            return pd.Series(values, index=index, dtype=float)
+
+        @staticmethod
+        def _dataframe_from_groupby(
+            groupby: list[str],
+            values: list[float],
+            location: str = "AT1",
+            unit: str = "MWh_th",
+        ) -> pd.DataFrame:
+            index = pd.MultiIndex.from_tuples(
+                [tuple({"location": location, "unit": unit}[k] for k in groupby)],
+                names=groupby,
+            )
+            columns = pd.Index(
+                pd.to_datetime(["2019-01-01", "2019-01-02"]), name="snapshot"
+            )
+            return pd.DataFrame([values[: len(columns)]], index=index, columns=columns)
+
+        def withdrawal(
+            self,
+            bus_carrier: str | list[str] | None = None,
+            carrier: list[str] | str | None = None,
+            components: str | list[str] | None = None,
+            aggregate_time: bool = True,
+            groupby: list[str] | None = None,
+            nice_names: bool | None = None,
+            **_: object,
+        ) -> pd.Series | pd.DataFrame:
+            self.calls.append(
+                {
+                    "bus_carrier": bus_carrier,
+                    "carrier": carrier,
+                    "components": components,
+                    "aggregate_time": aggregate_time,
+                    "groupby": groupby,
+                    "nice_names": nice_names,
+                }
+            )
+
+            if groupby is None:
+                groupby = ["location", "unit"]
+
+            if aggregate_time:
+                return self._series_from_groupby(groupby, [55.0])
+            return self._dataframe_from_groupby(groupby, [55.0, 56.0])
+
+    class _DistrictHeatNetwork:
+        """Minimal network exposing district-heat buses/links and statistics."""
+
+        def __init__(self):
+            self.statistics = (
+                TestFinalEnergyByCarrierDistrictHeat._DistrictHeatStatisticsAccessor()
+            )
+            self.buses = pd.DataFrame(
+                {
+                    "carrier": [
+                        "urban central heat",
+                        "urban central heat",
+                        "AC",
+                        "gas",
+                        "district heat storage",
+                        "biomass",
+                        "hydrogen",
+                    ]
+                },
+                index=[
+                    "AT1 urban central heat",
+                    "AT2 urban central heat",
+                    "AT1 AC",
+                    "AT2 gas",
+                    "AT1 heat storage",
+                    "AT2 biomass",
+                    "AT2 hydrogen",
+                ],
+            )
+            self.links = pd.DataFrame(
+                {
+                    "bus0": [
+                        "AT1 AC",
+                        "AT2 gas",
+                        "AT2 biomass",
+                        "AT2 hydrogen",
+                    ],
+                    "bus1": [
+                        "AT1 urban central heat",
+                        "AT2 urban central heat",
+                        "AT2 urban central heat",
+                        "AT2 urban central heat",
+                    ],
+                    "bus2": [
+                        "AT1 heat storage",
+                        "AT1 heat storage",
+                        "AT1 heat storage",
+                        "AT1 heat storage",
+                    ],
+                    "bus3": [
+                        "AT1 heat storage",
+                        "AT1 heat storage",
+                        "AT1 heat storage",
+                        "AT1 heat storage",
+                    ],
+                    "carrier": [
+                        "urban central resistive heater",
+                        "urban central gas boiler",
+                        "central heat charger",
+                        "central heat discharger",
+                    ],
+                },
+                index=["l1", "l2", "l3", "l4"],
+            )
+
+    def _district_heat_network(self):
+        return self._DistrictHeatNetwork()
+
+    def test_returns_series(self):
+        """Function returns a Series with expected output format."""
+        result = Final_Energy_by_Carrier__District_Heat(self._district_heat_network())
+        assert isinstance(result, pd.Series)
+        assert isinstance(result.index, pd.MultiIndex)
+        assert result.index.names == ["location", "unit"]
+
+    def test_filters_charger_and_discharger_carriers(self):
+        """Carrier query excludes charger/discharger links connected to central heat."""
+        network = self._district_heat_network()
+        _ = Final_Energy_by_Carrier__District_Heat(network)
+
+        calls = network.statistics.calls
+        assert len(calls) == 1
+        queried_carriers = set(calls[0]["carrier"])
+        assert queried_carriers == {
+            "urban central resistive heater",
+            "urban central gas boiler",
+        }
+
+    def test_uses_supply_bus_carriers_from_bus0(self):
+        """bus_carrier query uses carriers from bus0 of relevant central-heat links."""
+        network = self._district_heat_network()
+        _ = Final_Energy_by_Carrier__District_Heat(network)
+
+        queried_bus_carriers = set(network.statistics.calls[0]["bus_carrier"])
+        # Links via bus0 include AC, gas, biomass and hydrogen supply buses.
+        assert queried_bus_carriers == {"AC", "gas", "biomass", "hydrogen"}
+
+    def test_returns_dataframe_for_aggregate_per_year_false(self):
+        """aggregate_per_year=False returns timeseries DataFrame output."""
+        result = Final_Energy_by_Carrier__District_Heat(
+            self._district_heat_network(), aggregate_per_year=False
+        )
+        assert isinstance(result, pd.DataFrame)
+        assert isinstance(result.index, pd.MultiIndex)
+        assert result.index.names == ["location", "unit"]
+        assert isinstance(result.columns, pd.Index)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_statistics_functions.py
+++ b/tests/test_statistics_functions.py
@@ -796,6 +796,9 @@ class TestFinalEnergyByCarrierDistrictHeat:
             self.statistics = (
                 TestFinalEnergyByCarrierDistrictHeat._DistrictHeatStatisticsAccessor()
             )
+            self.snapshots = pd.DatetimeIndex(
+                pd.to_datetime(["2019-01-01", "2019-01-02"]), name="snapshot"
+            )
             self.buses = pd.DataFrame(
                 {
                     "carrier": [
@@ -888,13 +891,16 @@ class TestFinalEnergyByCarrierDistrictHeat:
 
     def test_returns_dataframe_for_aggregate_per_year_false(self):
         """aggregate_per_year=False returns timeseries DataFrame output."""
+        network = self._district_heat_network()
         result = Final_Energy_by_Carrier__District_Heat(
-            self._district_heat_network(), aggregate_per_year=False
+            network, aggregate_per_year=False
         )
         assert isinstance(result, pd.DataFrame)
         assert isinstance(result.index, pd.MultiIndex)
         assert result.index.names == ["location", "unit"]
-        assert isinstance(result.columns, pd.Index)
+        assert isinstance(result.columns, pd.DatetimeIndex)
+        assert len(result.columns) == len(network.snapshots)
+        pd.testing.assert_index_equal(result.columns, network.snapshots)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Short description of this pull request
Introduce new variable statistics Final Energy [by Carrier]|District Heat. 

> The energy demand of district heating is calculated based on the links from other carriers buses to the urban central heat buses. This includes waste heat from eg. DAC. Taking the withdrawal from the source bus of the link gives the energy in elem of the source carrier.

| variable | PyPSA-output | IAMC Energy Balance | Difference % | 🟢 🟡 🟠 🔴 |
| -- | -- | -- | -- | -- |
| Final Energy [by Carrier]\|District Heat | 6.6506e4| 6.8e4 | -1.1% | 🟢  in range |

---
### Checklist
Before asking for review, please make shure, the following steps are completed (whenever possible):
- [x] Changes are tested locally and behave as expected.
- [x] Code is documented using numpy-styled function docstrings
- [x] All tests succeed
- [x] All Sourcery-bot review suggestions have been implemented or rejected with an explanation.

_Sourcery-Bot starts to review your pull request, whenever it is created. This may take some time. After having finished these steps, please request for review in the Pull Request._

## Summary by Sourcery

Add support for computing final energy statistics for district heat by carrier and integrate it into the statistics mapping.

New Features:
- Introduce Final_Energy_by_Carrier__District_Heat to derive district heat final energy by carrier from PyPSA networks.
- Register the new district heat by carrier statistic in the default mapping configuration.

Tests:
- Add a dedicated test suite validating Final_Energy_by_Carrier__District_Heat output structure and selection of relevant buses and carriers.