### PR TITLE
70 new variable statistics net importselectricity

### DIFF
--- a/pypsa_validation_processing/class_definitions.py
+++ b/pypsa_validation_processing/class_definitions.py
@@ -671,16 +671,22 @@ class Network_Processor:
             )
 
         target_unit = match.iloc[0][unit_col]
-        if "[" in target_unit:
+        if ("[" in target_unit) and ("]" in target_unit) and ("," in target_unit):
             print(
                 "Several possible units defined for variable '{variable}' in common definitions. Take first one:".format(
                     variable=variable
                 )
             )
-            import ast
+            try:
+                import ast
 
-            target_unit = ast.literal_eval(target_unit)[0]
-            print(target_unit)
+                target_unit = ast.literal_eval(target_unit)[0]
+                print(target_unit)
+            except Exception as exc:
+                print(
+                    f"WARNING: Failed to parse multiple units for variable '{variable}': {exc}. Using TJ as unit."
+                )
+                target_unit = "TJ"
         if pd.isna(target_unit):
             raise KeyError(
                 f"Unit information not found for variable '{variable}' in common definitions."

--- a/pypsa_validation_processing/class_definitions.py
+++ b/pypsa_validation_processing/class_definitions.py
@@ -579,6 +579,16 @@ class Network_Processor:
             )
 
         target_unit = match.iloc[0][unit_col]
+        if "[" in target_unit:
+            print(
+                "Several possible units defined for variable '{variable}' in common definitions. Take first one:".format(
+                    variable=variable
+                )
+            )
+            import ast
+
+            target_unit = ast.literal_eval(target_unit)[0]
+            print(target_unit)
         if pd.isna(target_unit):
             raise KeyError(
                 f"Unit information not found for variable '{variable}' in common definitions."

--- a/pypsa_validation_processing/configs/mapping.default.yaml
+++ b/pypsa_validation_processing/configs/mapping.default.yaml
@@ -10,6 +10,7 @@ Final Energy [by Carrier]|Coal: Final_Energy_by_Carrier__Coal
 Final Energy [by Carrier]|Natural Gas: Final_Energy_by_Carrier__Natural_Gas
 Final Energy [by Carrier]|Oil: Final_Energy_by_Carrier__Oil
 Final Energy [by Carrier]|District Heat: Final_Energy_by_Carrier__District_Heat
+Net Imports|Electricity: Net_Imports__Electricity
 Final Energy [by Sector]|Transportation: Final_Energy_by_Sector__Transportation
 Final Energy [by Sector]|Industry: Final_Energy_by_Sector__Industry
 Final Energy [by Sector]|Agriculture: Final_Energy_by_Sector__Agriculture

--- a/pypsa_validation_processing/statistics_functions.py
+++ b/pypsa_validation_processing/statistics_functions.py
@@ -29,6 +29,7 @@ import pypsa
 from pypsa_validation_processing.utils import (
     statistics_kwargs_for_filtering as kwargs_filtering,
     statistics_kwargs as kwargs,
+    statistics_kwargs_for_imports as kwargs_imports,
     UNITS_MAPPING,
     remap_unit_index,
 )
@@ -133,6 +134,91 @@ def Final_Energy_by_Carrier__Electricity(
 
     result = pd.concat(series_list)
     return result
+
+
+def Net_Imports__Electricity(
+    n: pypsa.Network,
+    aggregate_per_year: bool = True,
+) -> pd.Series | pd.DataFrame:
+    """Extract net imports of electricity from a PyPSA Network.
+
+    Net imports are computed as imports minus exports over AC lines and DC
+    links. The pypsa-statistics energy-balance accessor already carries the
+    sign convention, so summing the signed balances of the domestic ports
+    yields the net import result directly.
+
+    Parameters
+    ----------
+    n : pypsa.Network
+        PyPSA network to process.
+    aggregate_per_year : bool, optional
+        If ``True`` (default), aggregate over all snapshots and return a
+        :class:`pandas.Series`. If ``False``, return a
+        :class:`pandas.DataFrame` with snapshots as columns.
+
+    Returns
+    -------
+    pd.Series | pd.DataFrame
+        Pandas Series (``aggregate_per_year=True``) or DataFrame
+        (``aggregate_per_year=False``) with MultiIndex of ``location`` and
+        ``unit``.
+        Returns data at regional level as provided by the PyPSA network.
+        Country-level aggregation is handled by
+        Network_Processor._aggregate_to_country() if configured.
+
+    Notes
+    -----
+    When ``aggregate_per_year`` is ``False``, the returned DataFrame keeps the
+    snapshot axis as columns and reports net imports per region and snapshot.
+    """
+    imports_raw = (
+        n.statistics.transmission(
+            bus_carrier=["AC", "DC"],
+            components=["Link", "Line"],
+            groupby_time=aggregate_per_year,
+            **kwargs_imports,
+        )
+        .groupby(["bus0", "bus1", "unit"])
+        .sum()
+    )
+
+    # process non-aggregated data - stack to long format with single column
+    if isinstance(imports_raw, pd.DataFrame):
+        imports_long = (
+            imports_raw.stack(future_stack=True)
+            .rename("value")
+            .rename_axis(index=["location_from", "location_to", "unit", "snapshot"])
+            .reset_index()
+        )
+        groupby_columns = ["location", "unit", "snapshot"]
+    # process aggregated data - process single column as is
+    else:
+        imports_long = (
+            imports_raw.rename("value")
+            .rename_axis(index=["location_from", "location_to", "unit"])
+            .reset_index()
+        )
+        groupby_columns = ["location", "unit"]
+
+    net_imports = pd.concat(
+        [
+            imports_long.assign(
+                location=imports_long["location_to"], value=imports_long["value"]
+            ),
+            imports_long.assign(
+                location=imports_long["location_from"], value=-imports_long["value"]
+            ),
+        ],
+        ignore_index=True,
+    )
+    net_imports_grouped = net_imports.groupby(groupby_columns, sort=False)[
+        "value"
+    ].sum()
+
+    if isinstance(imports_raw, pd.DataFrame):
+        return net_imports_grouped.unstack("snapshot")
+
+    return net_imports_grouped
 
 
 def Final_Energy_by_Carrier__Coal(

--- a/pypsa_validation_processing/statistics_functions.py
+++ b/pypsa_validation_processing/statistics_functions.py
@@ -171,7 +171,7 @@ def Net_Imports__Electricity(
 
     Notes
     -----
-    The evaluation pathway in this function strongly depnds on the input of the
+    The evaluation pathway in this function strongly depends on the input of the
     parameter ``aggregate_per_year``. Non-aggregated data (with ``aggregate_per_year`` is ``False``)
     are processed as :class:`pandas.DataFrame` in long-format, aggregated data
     (with ``aggregate_per_year`` is ``True``) are processed as they come.

--- a/pypsa_validation_processing/statistics_functions.py
+++ b/pypsa_validation_processing/statistics_functions.py
@@ -147,10 +147,8 @@ def Net_Imports__Electricity(
 ) -> pd.Series | pd.DataFrame:
     """Extract net imports of electricity from a PyPSA Network.
 
-    Net imports are computed as imports minus exports over AC lines and DC
-    links. The pypsa-statistics energy-balance accessor already carries the
-    sign convention, so summing the signed balances of the domestic ports
-    yields the net import result directly.
+    Evaluation of imports is performed on regional level, national
+    level is covered as a result of aggregation.
 
     Parameters
     ----------
@@ -173,8 +171,10 @@ def Net_Imports__Electricity(
 
     Notes
     -----
-    When ``aggregate_per_year`` is ``False``, the returned DataFrame keeps the
-    snapshot axis as columns and reports net imports per region and snapshot.
+    The evaluation pathway in this function strongly depnds on the input of the
+    parameter ``aggregate_per_year``. Non-aggregated data (with ``aggregate_per_year`` is ``False``)
+    are processed as :class:`pandas.DataFrame` in long-format, aggregated data
+    (with ``aggregate_per_year`` is ``True``) are processed as they come.
     """
     imports_raw = (
         n.statistics.transmission(

--- a/pypsa_validation_processing/utils.py
+++ b/pypsa_validation_processing/utils.py
@@ -153,6 +153,10 @@ statistics_kwargs_for_filtering = {
     "groupby": ["name", "bus", "carrier", "location", "unit"],
     "nice_names": False,
 }
+statistics_kwargs_for_imports = {
+    "groupby": ["bus0", "bus1", "unit"],
+    "nice_names": False,
+}
 # standardize MultiIndex
 statistics_grouping_index = ["location", "unit"]
 

--- a/tests/test_statistics_functions.py
+++ b/tests/test_statistics_functions.py
@@ -15,6 +15,7 @@ from pypsa_validation_processing.statistics_functions import (
     Final_Energy_by_Sector__Agriculture,
     Final_Energy_by_Sector__Residential_and_Commercial,
     Final_Energy_by_Sector__Transportation,
+    Net_Imports__Electricity,
 )
 
 from conftest import MockPyPSANetwork, MockNetworkCollection
@@ -221,6 +222,134 @@ class TestFinalEnergyByCarrierElectricity:
         assert calls[4]["bus_carrier"] == "AC"
         assert calls[4]["carrier"] == "DAC"
         assert calls[4]["components"] == "Link"
+
+
+# ---------------------------------------------------------------------------
+# Tests for Net_Imports__Electricity
+# ---------------------------------------------------------------------------
+
+
+class TestNetImportsElectricity:
+    """Test suite for Net_Imports__Electricity function."""
+
+    class _ElectricityTradeStatisticsAccessor:
+        """Minimal accessor for electricity net-import tests."""
+
+        def __init__(self):
+            self.calls: list[dict[str, object]] = []
+
+        @staticmethod
+        def _transmission_rows(groupby_time: bool) -> pd.Series | pd.DataFrame:
+            if groupby_time:
+                index = pd.MultiIndex.from_tuples(
+                    [("AT0", "AT1", "MWh_el"), ("AT1", "AT0", "MWh_el")],
+                    names=["bus0", "bus1", "unit"],
+                )
+                return pd.Series([15.0, 4.0], index=index, dtype=float)
+
+            timestamps = pd.date_range(
+                "2019-01-01", periods=4, freq="6h", name="snapshot"
+            )
+            return pd.DataFrame(
+                [
+                    {
+                        "bus0": "AT0",
+                        "bus1": "AT1",
+                        "unit": "MWh_el",
+                        timestamps[0]: 10.0,
+                        timestamps[1]: 5.0,
+                        timestamps[2]: 0.0,
+                        timestamps[3]: 0.0,
+                    },
+                    {
+                        "bus0": "AT1",
+                        "bus1": "AT0",
+                        "unit": "MWh_el",
+                        timestamps[0]: 1.0,
+                        timestamps[1]: 1.0,
+                        timestamps[2]: 1.0,
+                        timestamps[3]: 1.0,
+                    },
+                ]
+            )
+
+        def transmission(
+            self,
+            bus_carrier: str | None = None,
+            carrier: list[str] | str | None = None,
+            components: str | list[str] | None = None,
+            groupby: list[str] | None = None,
+            groupby_time: bool = True,
+            nice_names: bool | None = None,
+            **_: object,
+        ) -> pd.Series | pd.DataFrame:
+            self.calls.append(
+                {
+                    "bus_carrier": bus_carrier,
+                    "carrier": carrier,
+                    "components": components,
+                    "groupby": groupby,
+                    "groupby_time": groupby_time,
+                    "nice_names": nice_names,
+                }
+            )
+
+            if (
+                bus_carrier == ["AC", "DC"]
+                and carrier is None
+                and components == ["Link", "Line"]
+                and groupby == ["bus0", "bus1", "unit"]
+            ):
+                return self._transmission_rows(groupby_time)
+
+            return pd.DataFrame(columns=["bus0", "bus1", "unit", "value"])
+
+    class _ElectricityTradeNetwork:
+        """Minimal network exposing the custom electricity trade accessor."""
+
+        def __init__(self):
+            self.statistics = (
+                TestNetImportsElectricity._ElectricityTradeStatisticsAccessor()
+            )
+
+    def _electricity_trade_network(self):
+        return self._ElectricityTradeNetwork()
+
+    def test_returns_net_imports_in_expected_sign_convention(self):
+        """Net imports should equal imports minus exports."""
+        network = self._electricity_trade_network()
+
+        result = Net_Imports__Electricity(network)
+
+        assert isinstance(result, pd.Series)
+        assert isinstance(result.index, pd.MultiIndex)
+        assert result.index.names == ["location", "unit"]
+        assert result.loc[("AT1", "MWh_el")] == pytest.approx(11.0)
+        assert result.loc[("AT0", "MWh_el")] == pytest.approx(-11.0)
+
+        calls = network.statistics.calls
+        assert len(calls) == 1
+        assert calls[0]["bus_carrier"] == ["AC", "DC"]
+        assert calls[0]["components"] == ["Link", "Line"]
+        assert calls[0]["groupby"] == ["bus0", "bus1", "unit"]
+        assert calls[0]["groupby_time"] is True
+
+    def test_returns_dataframe_for_aggregate_per_year_false(self):
+        """aggregate_per_year=False returns a timeseries DataFrame."""
+        network = self._electricity_trade_network()
+
+        result = Net_Imports__Electricity(network, aggregate_per_year=False)
+        aggregated = Net_Imports__Electricity(network)
+
+        assert isinstance(result, pd.DataFrame)
+        assert isinstance(result.index, pd.MultiIndex)
+        assert result.index.names == ["location", "unit"]
+        assert any(isinstance(column, pd.Timestamp) for column in result.columns)
+        assert result.shape[1] == 4
+        pd.testing.assert_series_equal(
+            result.sum(axis=1), aggregated, check_names=False
+        )
+
 
 # ---------------------------------------------------------------------------
 # Tests for Final_Energy_by_Carrier__Oil

--- a/tests/test_statistics_functions.py
+++ b/tests/test_statistics_functions.py
@@ -350,6 +350,15 @@ class TestNetImportsElectricity:
             result.sum(axis=1), aggregated, check_names=False
         )
 
+        timestamps = list(result.columns)
+        ts0, ts1 = timestamps[0], timestamps[1]
+
+        # AT0->AT1=10, AT1->AT0=1 at ts0; AT0->AT1=5, AT1->AT0=1 at ts1.
+        assert result.loc[("AT1", "MWh_el"), ts0] == pytest.approx(9.0)
+        assert result.loc[("AT0", "MWh_el"), ts0] == pytest.approx(-9.0)
+        assert result.loc[("AT1", "MWh_el"), ts1] == pytest.approx(4.0)
+        assert result.loc[("AT0", "MWh_el"), ts1] == pytest.approx(-4.0)
+
 
 # ---------------------------------------------------------------------------
 # Tests for Final_Energy_by_Carrier__Oil


### PR DESCRIPTION
### Short description of this pull request
- Add a new function to extract the statistics of variable Net Imports|Electricity

> _Defined as:_    Net imports of electricity

- handles variables in common definitions holding multiple units by taking the first one 
- introduces a new kwargs - dict for import-variables. 

---
### Checklist
Before asking for review, please make shure, the following steps are completed (whenever possible):
- [x] Changes are tested locally and behave as expected.
- [x] Code is documented using numpy-styled function docstrings
- [x] All tests succeed
- [x] All Sourcery-bot review suggestions have been implemented or rejected with an explanation.

_Sourcery-Bot starts to review your pull request, whenever it is created. This may take some time. After having finished these steps, please request for review in the Pull Request._

## Summary by Sourcery

Add support for computing and exposing electricity net import statistics and handling variables with multiple possible units.

New Features:
- Introduce Net_Imports__Electricity statistics function to compute regional electricity net imports as annual aggregates or time series.
- Add dedicated statistics kwargs for import-related queries to standardize transmission statistics access.

Enhancements:
- Extend unit resolution from common definitions to handle variables with multiple possible units by selecting and parsing the first defined unit, with a safe fallback.

Tests:
- Add unit tests for Net_Imports__Electricity covering sign convention, annual aggregation, and time-series output behavior.