### PR TITLE
Add MkDocs documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    pull_requests:
+      - main
 
 permissions:
   contents: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches:
       - main
-    pull_requests:
-      - main
+    workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,37 @@
+name: Deploy documentation
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[docs]"
+
+      - name: Build documentation
+        run: mkdocs build --strict
+
+      - name: Deploy to GitHub Pages
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: mkdocs gh-deploy --force

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 # PyPSA-network processing for validation
 This repository is licensed under the [MIT License](https://github.com/maxnutz/pypsa_validation_processing/blob/main/LICENSE)
 
+Documentation: [https://maxnutz.github.io/pypsa_validation_processing/](https://maxnutz.github.io/pypsa_validation_processing/)
+
 > [!NOTE]  
 > This package is currently in an **early state of development**. Expect ongoing changes and updates. Documentation and Readme will be continuously updated with changes.
 

--- a/docs/additional-information.md
+++ b/docs/additional-information.md
@@ -1,0 +1,3 @@
+# Additional Information
+
+This page can be edited to include additional project-specific documentation.

--- a/docs/api/class_definitions.md
+++ b/docs/api/class_definitions.md
@@ -1,0 +1,3 @@
+# Class Definitions API
+
+::: pypsa_validation_processing.class_definitions

--- a/docs/api/package.md
+++ b/docs/api/package.md
@@ -1,0 +1,3 @@
+# Package API
+
+::: pypsa_validation_processing

--- a/docs/api/statistics_functions.md
+++ b/docs/api/statistics_functions.md
@@ -1,0 +1,3 @@
+# Statistics Functions API
+
+::: pypsa_validation_processing.statistics_functions

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -1,0 +1,3 @@
+# Utilities API
+
+::: pypsa_validation_processing.utils

--- a/docs/api/workflow.md
+++ b/docs/api/workflow.md
@@ -1,0 +1,3 @@
+# Workflow API
+
+::: pypsa_validation_processing.workflow

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# PyPSA Validation Processing
+
+This documentation site contains the API reference generated from the package docstrings and a small space for project-specific notes.
+
+Use the API Reference section for the automatically rendered module documentation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,35 @@
+site_name: pypsa-validation-processing
+site_description: Processing PyPSA output to IAMC variables for validation workflows
+site_url: https://maxnutz.github.io/pypsa_validation_processing/
+repo_name: maxnutz/pypsa_validation_processing
+repo_url: https://github.com/maxnutz/pypsa_validation_processing
+
+theme:
+  name: mkdocs
+
+nav:
+  - Home: index.md
+  - API Reference:
+      - Package: api/package.md
+      - Workflow: api/workflow.md
+      - Class Definitions: api/class_definitions.md
+      - Statistics Functions: api/statistics_functions.md
+      - Utilities: api/utils.md
+  - Additional Information: additional-information.md
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths:
+            - pypsa_validation_processing
+          options:
+            docstring_style: numpy
+            members: true
+            filters:
+              - "^_"
+            show_root_heading: true
+            show_root_full_path: false
+            show_signature_annotations: true
+            show_source: false

--- a/pixi.lock
+++ b/pixi.lock
@@ -4806,13 +4806,15 @@ packages:
 - pypi: ./
   name: pypsa-validation-processing
   version: 0.1.0
-  sha256: 953024074c672e544f88c215336b71c52543773a54b84864023e2d54b870568d
+  sha256: 9ad87a9b0b9d96ece862bc2eeb06cbe8de95020b78ae0e8568b442eb9657e272
   requires_dist:
   - pyyaml
   - pandas
   - pypsa
   - pyam-iamc
   - nomenclature-iamc
+  - mkdocs ; extra == 'docs'
+  - mkdocstrings[python] ; extra == 'docs'
   requires_python: '>=3.11'
 - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
   sha256: d016e04b0e12063fbee4a2d5fbb9b39a8d191b5a0042f0b8459188aedeabb0ca

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,12 @@ dependencies = [
     "nomenclature-iamc",
 ]
 
+[project.optional-dependencies]
+docs = [
+    "mkdocs",
+    "mkdocstrings[python]",
+]
+
 [project.urls]
 Homepage = "https://github.com/maxnutz/pypsa_validation_processing"
 


### PR DESCRIPTION
Adds a MkDocs documentation site with mkdocstrings-based API pages, an editable Additional Information page, and a GitHub Actions workflow that deploys to GitHub Pages from gh-pages on pushes to main. Also adds the documentation URL to the README and a docs optional dependency extra for local and CI installs.

## Summary by Sourcery

Set up a MkDocs documentation site with mkdocstrings-based API pages, wired to a new GitHub Actions workflow that builds and deploys the docs to GitHub Pages and is referenced from the project metadata and README.

New Features:
- Introduce a MkDocs-based documentation site with auto-generated API reference and an editable Additional Information section.

Build:
- Add a docs optional dependency group for installing MkDocs and mkdocstrings.

CI:
- Add a GitHub Actions workflow to build and deploy the documentation site to GitHub Pages on pushes to the main branch.

Documentation:
- Add initial documentation pages, including a landing page and mkdocstrings-backed API reference for core modules, and link the hosted docs from the README.