### PR TITLE
Document the Scenario Explorer on the docs landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,4 +192,10 @@ To register a new variable, please first open a new Issue and select Issue Templ
 - make sure that the newest version of main is merged into your feature branch
 - open a pull request and assign @maxnutz as reviewer
 
-**Note:** `docs/api/utils.md`, `docs/api/class_definitions.md`, and `docs/api/workflow.md` each use an explicit `members:` allowlist so that module-level constants and cross-module imports (e.g. `REGION_MAPPING`, `UNITS_MAPPING`, or a function/class imported from another module) don't leak into the rendered API docs. If you add a new public function or class to `utils.py`, `class_definitions.py`, or `workflow.py`, also add its name to the matching allowlist in `docs/api/*.md`. `docs/api/statistics_functions.md` instead uses an exclude-`filters` list, so new statistics functions are picked up automatically — no doc update needed when registering a new variable.
+## Documentation Pages
+`docs/api/utils.md`, `docs/api/class_definitions.md`, and `docs/api/workflow.md` each use an explicit `members:` allowlist so that module-level constants and cross-module imports (e.g. `REGION_MAPPING`, `UNITS_MAPPING`, or a function/class imported from another module) don't leak into the rendered API docs. `docs/api/statistics_functions.md` instead uses an exclude-`filters` list, so new statistics functions are picked up automatically — no doc update needed when registering a new variable.
+
+> [!NOTE]
+> If you add a new public function or class to `utils.py`, `class_definitions.py`, or `workflow.py`, also add its name to the matching allowlist in `docs/api/*.md`. 
+
+To render the docs locally for testing, run `pixi run mkdocs serve`. Docs are then available locally under an URL provided.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,12 +8,13 @@ Processed output from this package is intended for submission to the [PyPSA-AT S
 
 Keep the following in mind when preparing a submission:
 
-- **Model name:** the Explorer only accepts model names starting with `"Pypsa-AT v1.0"`. The `model_name` value in your config must exactly match one of the models defined in the [pypsa-at-dev-workflow mappings file](https://github.com/iiasa/pypsa-at-dev-workflow/blob/d71aab41172992f020a3fb149b166dee548a4543/mappings/pypsa-at_v1.x.yaml#L2) — set it accordingly in `config.default.yaml` (or your own config) before running the workflow.
+- **Model name:** the Explorer currently only accepts model names starting with `"Pypsa-AT v1.0"` as this is the model registered. The `model_name` value in your config must exactly match one of the models defined in the [pypsa-at-dev-workflow mappings file](https://github.com/iiasa/pypsa-at-dev-workflow/blob/d71aab41172992f020a3fb149b166dee548a4543/mappings/pypsa-at_v1.x.yaml#L2) — set it accordingly in `config.default.yaml` (or your own config) before running the workflow.
 - **Submission time:** large files can take a while to process; you will be notified by e-mail once the submission succeeds.
 - **Output format:** this package's exported Excel files are already formatted to fit Explorer submission requirements. A few config flags directly affect whether a submission validates:
   - `convert_units` — converts PyPSA units to the IAMC-valid units expected by the Explorer.
   - `map_country_codes_to_names` — controls whether output regions use country codes (`AT`) or full names (`Austria`); make sure this matches what the Explorer expects for your submission.
   - `aggregation_level` — controls whether output rows are aggregated to `country` or kept at `region` granularity.
+- **Common definitions:** The common definitions of variables and regions used in this processing step must be identical to the common definitions used for the pypsa-at-dev-workflow. This is currently enshured for by default.
 
 ## API Reference
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,24 @@
 # PyPSA Validation Processing
 
-This documentation site contains the API reference generated from the package docstrings and a small space for project-specific notes.
+This package processes PyPSA network results into IAMC-formatted variables for validation against the Eurostat Energy Balance, as part of the PyPSA-AT project.
 
-Use the API Reference section for the automatically rendered module documentation.
+## Scenario Explorer
+
+Processed output from this package is intended for submission to the [PyPSA-AT Scenario Explorer](https://pypsa-at-dev.apps.ece.iiasa.ac.at/). Submitting to the Explorer requires registering a user account on the site.
+
+Keep the following in mind when preparing a submission:
+
+- **Model name:** the Explorer only accepts model names starting with `"Pypsa-AT v1.0"`. The `model_name` value in your config must exactly match one of the models defined in the [pypsa-at-dev-workflow mappings file](https://github.com/iiasa/pypsa-at-dev-workflow/blob/d71aab41172992f020a3fb149b166dee548a4543/mappings/pypsa-at_v1.x.yaml#L2) — set it accordingly in `config.default.yaml` (or your own config) before running the workflow.
+- **Submission time:** large files can take a while to process; you will be notified by e-mail once the submission succeeds.
+- **Output format:** this package's exported Excel files are already formatted to fit Explorer submission requirements. A few config flags directly affect whether a submission validates:
+  - `convert_units` — converts PyPSA units to the IAMC-valid units expected by the Explorer.
+  - `map_country_codes_to_names` — controls whether output regions use country codes (`AT`) or full names (`Austria`); make sure this matches what the Explorer expects for your submission.
+  - `aggregation_level` — controls whether output rows are aggregated to `country` or kept at `region` granularity.
+
+## API Reference
+
+Use the API Reference section (nav) for the automatically rendered module documentation.
+
+## Contributing
+
+See [Contributing](contributing.md) for coding-style and participation guidelines.


### PR DESCRIPTION
## Summary
- Rewrite `docs/index.md` to lead with Scenario Explorer info (registration requirement, model-name matching rule, e-mail notification on large submissions) instead of burying it below the API-reference pointer.
- Call out the config flags that affect submission validity: `convert_units`, `map_country_codes_to_names`, `aggregation_level`.
- Add a `## Contributing` section linking to `contributing.md` (added in a follow-up PR for #82, part 3 of 3) — until that PR merges, `mkdocs build` emits a non-fatal warning for this one link (`target is not found among documentation files`); it resolves once the contributing page lands.

Part 2 of 3 for #82 (execution order: API docs cleanup → this → contributing page).

## Test plan
- [x] `mkdocs build` succeeds (one expected non-fatal warning for the not-yet-existing `contributing.md` link)
- [x] Manually reviewed rendered landing page content
- [x] `pixi run test` — 201 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rework the docs landing page to foreground Scenario Explorer usage and submission requirements before the API reference.

Documentation:
- Expand the docs landing page with detailed guidance for submitting processed outputs to the PyPSA-AT Scenario Explorer, including model name constraints, registration, and notification behavior.
- Highlight configuration flags that influence Scenario Explorer submission validity and briefly explain their impact on outputs.
- Add a Contributing section entry point on the docs landing page that links to the contributing guidelines page.